### PR TITLE
rpi-eeprom-update: Handle invalid date strings

### DIFF
--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -158,7 +158,7 @@ getCurrentVersion() {
       fi
    else
       # New bootloader / old firmware ? Try to parse the date
-      CURRENT_VERSION=$(date -u +%s --date "$(vcgencmd bootloader_version | head -n1)")
+      CURRENT_VERSION=$(date -u +%s --date "$(vcgencmd bootloader_version | head -n1)" 2>/dev/null || true)
    fi
 
    # Failed to parse the version. Default to the initial production release.


### PR DESCRIPTION
If 'vcgencmd bootloader-version' returns 'unknown' instead of a
timestamp then date will fail to parse the message. This should only
happen when debugging the firmware but handle the error anyway by
defaulting to the first bootloader release.