### PR TITLE
Restore machine output exit code as string

### DIFF
--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -454,12 +454,12 @@ checkVersion()
    if [ "${BOOTLOADER_UPDATE_VERSION}" -gt "${BOOTLOADER_CURRENT_VERSION}" ]; then
       echo "*** UPDATE REQUIRED ***"
       printVersions
-      write_status_info "${EXIT_UPDATE_REQUIRED}"
+      write_status_info "EXIT_UPDATE_REQUIRED"
       exit ${EXIT_UPDATE_REQUIRED}
    else
       echo "Bootloader EEPROM is up to date"
       printVersions
-      write_status_info "${EXIT_SUCCESS}"
+      write_status_info "EXIT_SUCCESS"
       exit ${EXIT_SUCCESS}
    fi
 }
@@ -485,7 +485,7 @@ EOF
    else
       cat > "${MACHINE_OUTPUT}" <<EOF
 {
-  "EXITCODE": ${exit_code},
+  "EXITCODE": "${exit_code}",
   "BOOTLOADER_CURRENT": ${bootloader_cur:-0},
   "BOOTLOADER_LATEST": ${bootloader_new:-0},
   "VL805_CURRENT": "${vl805_cur}",

--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -469,8 +469,8 @@ write_status_info()
    [ -z "${MACHINE_OUTPUT}" ] && return 0
 
    exit_code="${1:-EXIT_FAILED}"
-   bootloader_cur="${BOOTLOADER_CURRENT_VERSION}"
-   bootloader_new="${BOOTLOADER_UPDATE_VERSION}"
+   bootloader_cur="${BOOTLOADER_CURRENT_VERSION:-0}"
+   bootloader_new="${BOOTLOADER_UPDATE_VERSION:-0}"
    vl805_cur="${VL805_CURRENT_VERSION}"
    vl805_new="${VL805_UPDATE_VERSION}"
 
@@ -486,8 +486,8 @@ EOF
       cat > "${MACHINE_OUTPUT}" <<EOF
 {
   "EXITCODE": "${exit_code}",
-  "BOOTLOADER_CURRENT": ${bootloader_cur:-0},
-  "BOOTLOADER_LATEST": ${bootloader_new:-0},
+  "BOOTLOADER_CURRENT": ${bootloader_cur},
+  "BOOTLOADER_LATEST": ${bootloader_new},
   "VL805_CURRENT": "${vl805_cur}",
   "VL805_LATEST": "${vl805_new}"
 }


### PR DESCRIPTION
Also ensure 0 as default bootloader timestamp for both JSON and non-JSON.