### PR TITLE
Add Python3 support

### DIFF
--- a/rpi-eeprom-config
+++ b/rpi-eeprom-config
@@ -75,20 +75,26 @@ class BootloaderImage(object):
             pad = pad + 1
 
         if self._out is not None:
-           self._out.write(self._bytes)
-           self._out.close()
+            self._out.write(self._bytes)
+            self._out.close()
         else:
-           sys.stdout.write(self._bytes)
+            if hasattr(sys.stdout, 'buffer'):
+                sys.stdout.buffer.write(self._bytes)
+            else:
+                sys.stdout.write(self._bytes)
 
     def read(self):
         hdr_offset, length = self.find_config()
         offset = hdr_offset + 4 + FILE_HDR_LEN
         config_bytes = self._bytes[offset:offset+length-FILENAME_LEN-4]
         if self._out is not None:
-           self._out.write(config_bytes)
-           self._out.close()
+            self._out.write(config_bytes)
+            self._out.close()
         else:
-           sys.stdout.write(config_bytes)
+            if hasattr(sys.stdout, 'buffer'):
+                sys.stdout.buffer.write(config_bytes)
+            else:
+                sys.stdout.write(config_bytes)
 
 def main():
     parser = argparse.ArgumentParser('RPI EEPROM config tool')


### PR DESCRIPTION
This PR is maybe not the best ("most Pythonic") fix, but it works...

With Python3, the following errors occur:
```
rpi4:~/zz1 # rpi-eeprom-config --config old.config /usr/lib/kernel-overlays/base/lib/firmware/raspberrypi/bootloader/critical/pieeprom-2019-09-10.bin >new.bin
Traceback (most recent call last):
  File "/usr/bin/rpi-eeprom-config", line 107, in <module>
    main()
  File "/usr/bin/rpi-eeprom-config", line 102, in main
    image.write(args.config)
  File "/usr/bin/rpi-eeprom-config", line 81, in write
    sys.stdout.write(self._bytes)
TypeError: write() argument must be str, not bytearray
```
and
```
rpi4:~/zz1 # rpi-eeprom-config /usr/lib/kernel-overlays/base/lib/firmware/raspberrypi/bootloader/critical/pieeprom-2019-09-10.bin  >new.config
Traceback (most recent call last):
  File "/usr/bin/rpi-eeprom-config", line 107, in <module>
    main()
  File "/usr/bin/rpi-eeprom-config", line 104, in main
    image.read()
  File "/usr/bin/rpi-eeprom-config", line 91, in read
    sys.stdout.write(config_bytes)
TypeError: write() argument must be str, not bytearray
```

Output with Python2 and Python3 is now identical with this PR.

Also fixes inconsistent indenting.