### PR TITLE
use lspci if available instead of vl805. Avoid calling vl805 twice.

### DIFF
--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -388,8 +388,13 @@ getVL805CurrentVersion()
    # root then treat the version as unknown and skip VLI updates.
    VL805_CURRENT_VERSION=""
    if [ "$(id -u)" = "0" ]; then
-      if vl805 | grep -q "VL805 FW version"; then
-         VL805_CURRENT_VERSION=$(vl805 | grep "VL805 FW version" | awk '{print $4}')
+      if command -v lspci >/dev/null; then
+         vlver="$(lspci -d 1106:3483 -xxx | awk '/^50:/ { print "VL805 FW version: " $5 $4 $3 $2 }')"
+      else
+         vlver="$(vl805 | grep "VL805 FW version")"
+      fi
+      if [ -n "${vlver}" ]; then
+         VL805_CURRENT_VERSION="${vlver#*: }"
       fi
    fi
 }


### PR DESCRIPTION
`vl805` is really quite slow for some reason - when called it quickly outputs the version number, then there's about a 1 second delay for no apparent reason.

`rpi-eeprom-update` calls `vl805` twice to `grep` the version number incurring this delay two times. This change avoids the second unnecessary call on systems without `lspci`.

`lspci` is also much quicker, and will now be used instead of `vl805` when it is available (ref: https://github.com/raspberrypi/rpi-eeprom/issues/48#issuecomment-550527518).

#### BEFORE (two `vl805` calls):
```
rpi4:~ # time /usr/bin/rpi-eeprom-update
BOOTLOADER: up-to-date
CURRENT: Tue Sep 10 10:41:50 UTC 2019 (1568112110)
 LATEST: Tue Sep 10 10:41:50 UTC 2019 (1568112110)
VL805: up-to-date
CURRENT: 000137ab
 LATEST: 000137ab
real    0m 2.05s
user    0m 0.09s
sys     0m 1.94s
```

#### AFTER (using `lspci`):
```
BOOTLOADER: up-to-date
CURRENT: Tue Sep 10 10:41:50 UTC 2019 (1568112110)
 LATEST: Tue Sep 10 10:41:50 UTC 2019 (1568112110)
VL805: up-to-date
CURRENT: 000137ab
 LATEST: 000137ab
real    0m 0.10s
user    0m 0.06s
sys     0m 0.06s
```
#### AFTER (single `vl805` call):
```
rpi4:~ # /usr/bin/rpi-eeprom-update
BOOTLOADER: up-to-date
CURRENT: Tue Sep 10 10:41:50 UTC 2019 (1568112110)
 LATEST: Tue Sep 10 10:41:50 UTC 2019 (1568112110)
VL805: up-to-date
CURRENT: 000137ab
 LATEST: 000137ab
real    0m 1.13s
user    0m 0.08s
sys     0m 1.04s
```