### PR TITLE
rpi-eeprom-config - fix up help text (and therefore also man page)

### DIFF
--- a/rpi-eeprom-config
+++ b/rpi-eeprom-config
@@ -113,7 +113,7 @@ combination of the original EEPROM image file, along with the new bootloader \
 configuration.')
     parser.add_argument('--config', help='Filename of new bootloader config')
     parser.add_argument('--out', help='Name of output file')
-    parser.add_argument('EEPROM', help='EEPROM filename (pieeprom.bin)')
+    parser.add_argument('eeprom', help='EEPROM filename (pieeprom.bin)')
     args = parser.parse_args()
 
     image = BootloaderImage(args.eeprom, args.out)

--- a/rpi-eeprom-config
+++ b/rpi-eeprom-config
@@ -98,9 +98,9 @@ class BootloaderImage(object):
 
 def main():
     parser = argparse.ArgumentParser('RPI EEPROM config tool')
-    parser.add_argument('--config', help='Filename of new bootloader config')
-    parser.add_argument('--out', help='Filename for the EEPROM image with updated config')
-    parser.add_argument('eeprom', help='EEPROM filename (pieeprom.bin)')
+    parser.add_argument('--config', help='Insert new bootloader config into EEPROM image. CONFIG specifies the file containing the new config.')
+    parser.add_argument('--out', help='Extract current bootloader config from EEPROM image. OUT specifies the file to put the config into.')
+    parser.add_argument('eeprom', help='Name of EEPROM image file (e.g. pieeprom.bin)')
     args = parser.parse_args()
 
     image = BootloaderImage(args.eeprom, args.out)

--- a/rpi-eeprom-config
+++ b/rpi-eeprom-config
@@ -97,10 +97,23 @@ class BootloaderImage(object):
                 sys.stdout.write(config_bytes)
 
 def main():
-    parser = argparse.ArgumentParser('RPI EEPROM config tool')
-    parser.add_argument('--config', help='Insert new bootloader config into EEPROM image. CONFIG specifies the file containing the new config.')
-    parser.add_argument('--out', help='Extract current bootloader config from EEPROM image. OUT specifies the file to put the config into.')
-    parser.add_argument('eeprom', help='Name of EEPROM image file (e.g. pieeprom.bin)')
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, \
+    description='RPI EEPROM config tool. \
+\n\nThere are 3 operating modes: \
+\n\n1. Output the bootloader configuration stored in an EEPROM image file to \
+the screen (STDOUT): specify only the name of an EEPROM image file using the \
+EEPROM option. \
+\n\n2. Output the bootloader configuration stored in an EEPROM image file to a \
+file: specify the EEPROM image file using the EEPROM option, and the output file\
+using the --out option. \
+\n\n3. Insert a new bootloader configuration into an EEPROM image file: specify \
+the EEPROM image file using the EEPROM option, the bootloader configuration file\
+using the --config option, and the name to use for the new file which will be a \
+combination of the original EEPROM image file, along with the new bootloader \
+configuration.')
+    parser.add_argument('--config', help='Filename of new bootloader config')
+    parser.add_argument('--out', help='Name of output file')
+    parser.add_argument('EEPROM', help='EEPROM filename (pieeprom.bin)')
     args = parser.parse_args()
 
     image = BootloaderImage(args.eeprom, args.out)


### PR DESCRIPTION
The current help text for rpi-eeprom-config is unclear. This PR changes them so that the help text matches what the tool does and what each parameter specifies. The man page, automatically derived from the help text, is also fixed.