### PR TITLE
Add automated custom EEPROM configuration

### DIFF
--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -22,6 +22,8 @@ RECOVERY_BIN=${RECOVERY_BIN:-${FIRMWARE_ROOT}/${FIRMWARE_RELEASE_STATUS}/recover
 BOOTFS=${BOOTFS:-/boot}
 VCMAILBOX=${VCMAILBOX:-/opt/vc/bin/vcmailbox}
 
+CUSTOM_EEPROM_CONFIG=${CUSTOM_EEPROM_CONFIG:-/etc/default/rpi-eeprom-config}
+
 EXIT_SUCCESS=0
 EXIT_UPDATE_REQUIRED=1
 EXIT_FAILED=2
@@ -29,7 +31,7 @@ EXIT_EEPROM_FROZEN=3
 # Reserved
 # EXIT_PREVIOUS_UPDATE_FAILED=4
 
-OVERWRITE_CONFIG=0
+USE_EEPROM_INTERNAL_CONFIG=0
 # Maximum safe SPI speed for EEPROM access 16000, slower is ok.
 SPI_SPEED=16000
 # Timestamp for first release which doesn't have a timestamp field
@@ -54,8 +56,11 @@ cleanup() {
    if [ -f "${TMP_EEPROM_IMAGE}" ]; then
       rm -f "${TMP_EEPROM_IMAGE}"
    fi
-   if [ -f "${TMP_EEPROM_CONFIG}" ]; then
-      rm -f "${TMP_EEPROM_CONFIG}"
+   if [ -f "${TMP_CURRENT_EEPROM_CONFIG}" ]; then
+      rm -f "${TMP_CURRENT_EEPROM_CONFIG}"
+   fi
+   if [ -f "${TMP_NEW_EEPROM_CONFIG}" ]; then
+      rm -f "${TMP_NEW_EEPROM_CONFIG}"
    fi
    if [ -d "${TMP_BOOTFS_MNT}" ]; then
       umount "${TMP_BOOTFS_MNT}"
@@ -63,7 +68,8 @@ cleanup() {
    fi
    TMP_BOOTFS_MNT=
    TMP_EEPROM_IMAGE=
-   TMP_EEPROM_CONFIG=
+   TMP_CURRENT_EEPROM_CONFIG=
+   TMP_NEW_EEPROM_CONFIG=
 }
 trap cleanup EXIT
 
@@ -76,28 +82,48 @@ prepareImage()
 {
    [ -f "${BOOTLOADER_UPDATE_IMAGE}" ] || die "EEPROM image \'${BOOTLOADER_UPDATE_IMAGE}\' not found"
    TMP_EEPROM_IMAGE="$(mktemp)"
-   TMP_EEPROM_CONFIG="$(mktemp)"
+   TMP_CURRENT_EEPROM_CONFIG="$(mktemp)"
 
-   mkdir -p "${FIRMWARE_BACKUP_DIR}"
+   vcgencmd bootloader_config > "${TMP_CURRENT_EEPROM_CONFIG}"
 
    # Backup the configuration of the currently loaded bootloader
-   vcgencmd bootloader_config > "${TMP_EEPROM_CONFIG}"
+   mkdir -p "${FIRMWARE_BACKUP_DIR}"
    backup="${FIRMWARE_BACKUP_DIR}/pieeprom-backup-$(date +%Y%m%d-%H%M%S).conf"
-   cp -f "${TMP_EEPROM_CONFIG}" "${backup}"
-
-   if [ "$(wc -l "${TMP_EEPROM_CONFIG}" | awk '{print $1}')" -lt 3 ]; then
-      # Don't propagate empty EEPROM config files and also prevent the initial
-      # bootloader config with WAKE_ON_GPIO=0 propgating to newer versions by
-      # accident.
-      OVERWRITE_CONFIG=1
-   fi
+   cp -f "${TMP_CURRENT_EEPROM_CONFIG}" "${backup}"
 
    cp -f "${BOOTLOADER_UPDATE_IMAGE}" "${TMP_EEPROM_IMAGE}"
 
-   if [ "${OVERWRITE_CONFIG}" = 0 ]; then
+   if [ "${USE_EEPROM_INTERNAL_CONFIG}" = 0 ]; then
+      TMP_NEW_EEPROM_CONFIG="$(mktemp)"
+      rpi-eeprom-config "${TMP_EEPROM_IMAGE}" --out "${TMP_NEW_EEPROM_CONFIG}"
+
+      # Clean up empty lines
+      sed -i -e 's/[\t ]//g;/^$/d' "${TMP_NEW_EEPROM_CONFIG}"
+
+      no_of_eeprom_config_properties="$(wc -l "${TMP_CURRENT_EEPROM_CONFIG}" | awk '{print $1}')"
+      if [ "$no_of_eeprom_config_properties" -lt 3 ]; then
+         # Prevent the initial bootloader config with WAKE_ON_GPIO=0
+         # propagating to newer versions by accident
+         sed -i 's/WAKE_ON_GPIO=.*/WAKE_ON_GPIO=1/1' "${TMP_NEW_EEPROM_CONFIG}"
+      fi
+
+      # Apply current config settings to new EEPROM config
+      while read line; do
+         field=$(echo "${line}" | cut -d'=' -f1)
+         sed -i "s/${field}=.*/${line}/1" "${TMP_NEW_EEPROM_CONFIG}"
+      done < "${TMP_CURRENT_EEPROM_CONFIG}"
+
+      # Apply user customisations to new EEPROM config
+      if [ -f "${CUSTOM_EEPROM_CONFIG}" ]; then
+         while read line; do
+            field=$(echo "${line}" | cut -d'=' -f1)
+            sed -i "s/${field}=.*/${line}/1" "${TMP_NEW_EEPROM_CONFIG}"
+         done < "${CUSTOM_EEPROM_CONFIG}"
+      fi
+
       "${script_dir}/rpi-eeprom-config" \
          --out "${TMP_EEPROM_IMAGE}" \
-         --config "${TMP_EEPROM_CONFIG}" "${BOOTLOADER_UPDATE_IMAGE}"
+         --config "${TMP_NEW_EEPROM_CONFIG}" "${BOOTLOADER_UPDATE_IMAGE}"
    fi
 }
 
@@ -113,20 +139,20 @@ applyRecoveryUpdate()
    # if an actual public key signature is required then that plus any other
    # data would be appended after the SHA256 signature.
    if [ -n "${BOOTLOADER_UPDATE_IMAGE}" ]; then
-        [ -f "${BOOTLOADER_UPDATE_IMAGE}" ] || die "${BOOTLOADER_UPDATE_IMAGE} not found"
+      [ -f "${BOOTLOADER_UPDATE_IMAGE}" ] || die "${BOOTLOADER_UPDATE_IMAGE} not found"
 
-        TMP_EEPROM_IMAGE="$(mktemp)"
-        prepareImage
-        # If recovery.bin encounters pieeprom.upd then it will select it in
-        # preference to pieeprom.bin. The .upd file also causes recovery.bin
-        # to rename itself to recovery.000 and reboot if the update is successful.
-        # The rename causes the ROM to ignore this file and use the newly flashed
-        # EEPROM image instead.
-        sha256sum "${TMP_EEPROM_IMAGE}" | awk '{print $1}' > "${BOOTFS}/pieeprom.sig" \
-                || die "Failed to create ${BOOTFS}/pieeprom.sig"
+      prepareImage
 
-        cp -f "${TMP_EEPROM_IMAGE}" "${BOOTFS}/pieeprom.upd" \
-                || die "Failed to copy ${TMP_EEPROM_IMAGE} to ${BOOTFS}"
+      # If recovery.bin encounters pieeprom.upd then it will select it in
+      # preference to pieeprom.bin. The .upd file also causes recovery.bin
+      # to rename itself to recovery.000 and reboot if the update is successful.
+      # The rename causes the ROM to ignore this file and use the newly flashed
+      # EEPROM image instead.
+      sha256sum "${TMP_EEPROM_IMAGE}" | awk '{print $1}' > "${BOOTFS}/pieeprom.sig" \
+               || die "Failed to create ${BOOTFS}/pieeprom.sig"
+
+      cp -f "${TMP_EEPROM_IMAGE}" "${BOOTFS}/pieeprom.upd" \
+               || die "Failed to copy ${TMP_EEPROM_IMAGE} to ${BOOTFS}"
    fi
 
    if [ -n "${VL805_UPDATE_IMAGE}" ]; then
@@ -170,9 +196,9 @@ applyUpdate() {
       modprobe spidev
       modprobe spi-bcm2835
 
-      prepareImage "${BOOTLOADER_UPDATE_IMAGE}"
+      prepareImage
 
-      echo "Applying bootloaer update ${BOOTLOADER_UPDATE_IMAGE}"
+      echo "Applying bootloader update ${BOOTLOADER_UPDATE_IMAGE}"
       flashrom -p "linux_spi:dev=/dev/spidev0.0,spispeed=${SPI_SPEED}" -w "${TMP_EEPROM_IMAGE}" || die "flashrom EEPROM update failed"
 
       dtparam -R spi-gpio40-45
@@ -242,7 +268,7 @@ checkDependencies() {
 
    if ! command -v vl805 > /dev/null; then
       die "vl805 command not found. On Debian, try reinstalling the rpi-eeprom package."
-   fi 
+   fi
 
    if vcgencmd bootloader_config | grep -qi "Command not registered"; then
       die "vcgencmd: 'bootloader_config' command not supported. Please update VC firmware and reboot."
@@ -279,14 +305,14 @@ rpi-eeprom-update [options]... [FILE]
    Checks whether the Raspberry Pi bootloader and the VL805 USB controller
    EEPROMs are up-to-date and optionally updates the EEPROMs at the next reboot.
 
-   The default update mechanism writes recovery.bin and the EEPROM update 
-   image(s) (pieeprom.upd and vl805.bin) to the boot partition on the sd-card. 
+   The default update mechanism writes recovery.bin and the EEPROM update
+   image(s) (pieeprom.upd and vl805.bin) to the boot partition on the sd-card.
    The SHA256 hash of the corresponding images are written to pieeprom.sig
    and/or vl805.sig. This guards against file system corruption which could
    cause the EEPROM to be flashed with an invalid image. This is not a
    security check.
 
-   At the next reboot the ROM runs recovery.bin which updates EEPROM(s). 
+   At the next reboot the ROM runs recovery.bin which updates EEPROM(s).
    If the update was successful recovery.bin renames itself to recovery.000
    to prevent it from running a second time then resets the system.
    The system should then boot normally.
@@ -306,7 +332,8 @@ rpi-eeprom-update [options]... [FILE]
 
    -a Automatically install bootloader and USB (VLI) EEPROM updates.
    -A Specify which type of EEPROM to automatically update (vl805 or bootloader)
-   -d Use the default bootloader config instead of migrating the current settings
+   -d Use the default bootloader config (provided in the EEPROM image to be installed)
+      instead of migrating current settings
    -f Install the given file instead of the latest applicable update
       Ignores the FREEZE_VERSION flag in bootloader and is intended for manual
       firmware updates.
@@ -319,17 +346,21 @@ rpi-eeprom-update [options]... [FILE]
    -r Removes temporary EEPROM update files from the boot partition.
    -u Install the specified VL805 (USB EEPROM) image file.
 
-   To extract the configuration file from an EEPROM image: 
+   To extract the configuration file from an EEPROM image:
    rpi-eeprom-config pieeprom.bin --out bootconf.txt
 
-   To update the configuration file in an EEPROM image: 
+   To update the configuration file in an EEPROM image:
    rpi-eeprom-config pieeprom.bin --config bootconf.txt --out pieeprom-new.bin
 
-   To flash the new image: 
+   To flash the new image:
    sudo rpi-eeprom-update -d -f ./pieeprom-new.bin
 
-   The syntax is the same as config.txt but section filters etc are not supported. See
-   online documentation for the list of parameters.
+   Custom bootloader configurations can also be specified in ${CUSTOM_EEPROM_CONFIG}.
+   rpi-eeprom-update will ensure that these modifications are applied during upgrades,
+   providing a fully automatic way to apply configuration customisations.
+
+   Bootloader configuration file syntax is the same as config.txt, but section filters
+   etc. are not supported. See online documentation for the list of parameters.
 
    The official documentation for the Raspberry Pi bootloader EEPROM is available at
    https://www.raspberrypi.org/documentation/hardware/raspberrypi/booteeprom.md
@@ -405,7 +436,7 @@ getVL805UpdateVersion()
    # The latest VL805 version is indicated by a file containing the version
    # number. If the version file exists then verify that the corresponding
    # VL805 binary exists before selecting it.
-   # There are no user modifiable sections in the VL805 firmware and there 
+   # There are no user modifiable sections in the VL805 firmware and there
    # are unlikely to be many updates to it so just indicate the latest supported
    # version. This also avoids making any assumptions about the VLI version numbers.
    VL805_UPDATE_VERSION=""
@@ -569,7 +600,7 @@ while getopts A:adhif:m:ju:r option; do
    a) AUTO_UPDATE_BOOTLOADER=1
       AUTO_UPDATE_VL805=1
       ;;
-   d) OVERWRITE_CONFIG=1
+   d) USE_EEPROM_INTERNAL_CONFIG=1
       ;;
    f) BOOTLOADER_UPDATE_IMAGE="${OPTARG}"
       ;;

--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -110,7 +110,7 @@ prepareImage()
       # Apply current config settings to new EEPROM config
       while read line; do
          field=$(echo "${line}" | cut -d'=' -f1)
-         sed -i "s/${field}=.*/${line}/1" "${TMP_NEW_EEPROM_CONFIG}"
+         sed -i -e "s/${field}=.*/${line}/1" "${TMP_NEW_EEPROM_CONFIG}"
       done < "${TMP_CURRENT_EEPROM_CONFIG}"
 
       # Apply user customisations to new EEPROM config

--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -120,7 +120,7 @@ prepareImage()
             field="$(echo "${line}" | cut -d'=' -f1)"
 
             if grep -q "${field}" "${TMP_NEW_EEPROM_CONFIG}"; then
-               if [ "${field}" = "FREEZE_VERSION" ]l; then
+               if [ "${field}" = "FREEZE_VERSION" ]; then
                   echo "WARNING: Skipping ${line} from custom EEPROM configuration..."
                   echo "If you wish to prevent firmware updates from the OS, disable the rpi-eeprom-update systemd service."
                else

--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -104,7 +104,7 @@ prepareImage()
       if [ "$no_of_eeprom_config_properties" -lt 3 ]; then
          # Prevent the initial bootloader config with WAKE_ON_GPIO=0
          # propagating to newer versions by accident
-         sed -i 's/WAKE_ON_GPIO=.*/WAKE_ON_GPIO=1/1' "${TMP_NEW_EEPROM_CONFIG}"
+         sed -i -e 's/WAKE_ON_GPIO=.*/WAKE_ON_GPIO=1/1' "${TMP_NEW_EEPROM_CONFIG}"
       fi
 
       # Apply current config settings to new EEPROM config

--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -6,8 +6,13 @@ set -e
 
 script_dir=$(cd "$(dirname "$0")" && pwd)
 
+die() {
+   echo "$@" >&2
+   exit ${EXIT_FAILED}
+}
+
 if [ -f /etc/default/rpi-eeprom-update ]; then
-   [ shellcheck -e SC2148,SC2034 "${CUSTOM_EEPROM_CONFIG}" ] || die "Invalid rpi-eeprom-update configuration at ${CUSTOM_EEPROM_CONFIG}"
+   shellcheck -e SC2148,SC2034 /etc/default/rpi-eeprom-update || die "Invalid rpi-eeprom-update configuration at /etc/default/rpi-eeprom-update"
    . /etc/default/rpi-eeprom-update
 fi
 
@@ -74,11 +79,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-die() {
-   echo "$@" >&2
-   exit ${EXIT_FAILED}
-}
-
 prepareImage()
 {
    [ -f "${BOOTLOADER_UPDATE_IMAGE}" ] || die "EEPROM image \'${BOOTLOADER_UPDATE_IMAGE}\' not found"
@@ -116,13 +116,14 @@ prepareImage()
 
       # Apply user customisations to new EEPROM config
       if [ -f "${CUSTOM_EEPROM_CONFIG}" ]; then
-         [ shellcheck -e SC2148,SC2034 "${CUSTOM_EEPROM_CONFIG}" ] || die "Invalid custom EEPROM configuration at ${CUSTOM_EEPROM_CONFIG}"
+         shellcheck -e SC2148,SC2034 "${CUSTOM_EEPROM_CONFIG}" || die "Invalid custom EEPROM configuration at ${CUSTOM_EEPROM_CONFIG}"
 
+         echo "\n*** APPLYING CUSTOM EEPROM CONFIGURATION ***"
          while read line; do
             field="$(echo "${line}" | cut -d'=' -f1)"
 
             if grep -q "${field}" "${TMP_NEW_EEPROM_CONFIG}"; then
-               if [ "${field}" == "FREEZE_VERSION" ]l; then
+               if [ "${field}" = "FREEZE_VERSION" ]l; then
                   echo "WARNING: Skipping ${line} from custom EEPROM configuration..."
                   echo "If you wish to prevent firmware updates from the OS, disable the rpi-eeprom-update systemd service."
                else

--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -124,7 +124,7 @@ prepareImage()
                   echo "WARNING: Skipping ${line} from custom EEPROM configuration..."
                   echo "If you wish to prevent firmware updates from the OS, disable the rpi-eeprom-update systemd service."
                else
-                  sed -i "s/${field}=.*/${line}/1" "${TMP_NEW_EEPROM_CONFIG}"
+                  sed -i -e "s/${field}=.*/${line}/1" "${TMP_NEW_EEPROM_CONFIG}"
                fi
             else
                echo "WARNING: Skipping ${field} from custom EEPROM configuration..."

--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -121,6 +121,10 @@ prepareImage()
          done < "${CUSTOM_EEPROM_CONFIG}"
       fi
 
+      echo "\nBootloader configuration:"
+      cat "${TMP_NEW_EEPROM_CONFIG}"
+      echo ""
+
       "${script_dir}/rpi-eeprom-config" \
          --out "${TMP_EEPROM_IMAGE}" \
          --config "${TMP_NEW_EEPROM_CONFIG}" "${BOOTLOADER_UPDATE_IMAGE}"

--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -116,8 +116,19 @@ prepareImage()
       # Apply user customisations to new EEPROM config
       if [ -f "${CUSTOM_EEPROM_CONFIG}" ]; then
          while read line; do
-            field=$(echo "${line}" | cut -d'=' -f1)
-            sed -i "s/${field}=.*/${line}/1" "${TMP_NEW_EEPROM_CONFIG}"
+            field="$(echo "${line}" | cut -d'=' -f1)"
+
+            if grep -q "${field}" "${TMP_NEW_EEPROM_CONFIG}"; then
+               if [ "${field}" == "FREEZE_VERSION" ]l; then
+                  echo "WARNING: Skipping ${line} from custom EEPROM configuration..."
+                  echo "If you wish to prevent firmware updates from the OS, disable the rpi-eeprom-update systemd service."
+               else
+                  sed -i "s/${field}=.*/${line}/1" "${TMP_NEW_EEPROM_CONFIG}"
+               fi
+            else
+               echo "WARNING: Skipping ${field} from custom EEPROM configuration..."
+               echo "Not found in configuration from EEPROM to be installed."
+            fi
          done < "${CUSTOM_EEPROM_CONFIG}"
       fi
 
@@ -361,7 +372,10 @@ rpi-eeprom-update [options]... [FILE]
 
    Custom bootloader configurations can also be specified in ${CUSTOM_EEPROM_CONFIG}.
    rpi-eeprom-update will ensure that these modifications are applied during upgrades,
-   providing a fully automatic way to apply configuration customisations.
+   providing a fully automatic way to apply configuration customisations. Note that
+   FREEZE_VERSION is specifically ignored in this context - if you wish to prevent
+   updates to the firmware from the OS, simply disable the rpi-eeprom-update systemd
+   service.
 
    Bootloader configuration file syntax is the same as config.txt, but section filters
    etc. are not supported. See online documentation for the list of parameters.
@@ -631,7 +645,7 @@ done
 
 checkDependencies
 if [ "${AUTO_UPDATE_BOOTLOADER}" = 1 ] || [ "${AUTO_UPDATE_VL805}" = 1 ]; then
-   if vcgencmd bootloader_config | grep FREEZE_VERSION=1; then
+   if vcgencmd bootloader_config | grep "FREEZE_VERSION=1"; then
       echo "EEPROM version is frozen. Skipping update"
       exit ${EXIT_EEPROM_FROZEN}
    else

--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -12,7 +12,6 @@ die() {
 }
 
 if [ -f /etc/default/rpi-eeprom-update ]; then
-   shellcheck -e SC2148,SC2034 /etc/default/rpi-eeprom-update || die "Invalid rpi-eeprom-update configuration at /etc/default/rpi-eeprom-update"
    . /etc/default/rpi-eeprom-update
 fi
 
@@ -116,8 +115,6 @@ prepareImage()
 
       # Apply user customisations to new EEPROM config
       if [ -f "${CUSTOM_EEPROM_CONFIG}" ]; then
-         shellcheck -e SC2148,SC2034 "${CUSTOM_EEPROM_CONFIG}" || die "Invalid custom EEPROM configuration at ${CUSTOM_EEPROM_CONFIG}"
-
          echo "\n*** APPLYING CUSTOM EEPROM CONFIGURATION ***"
          while read line; do
             field="$(echo "${line}" | cut -d'=' -f1)"

--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -7,6 +7,7 @@ set -e
 script_dir=$(cd "$(dirname "$0")" && pwd)
 
 if [ -f /etc/default/rpi-eeprom-update ]; then
+   [ shellcheck -e SC2148,SC2034 "${CUSTOM_EEPROM_CONFIG}" ] || die "Invalid rpi-eeprom-update configuration at ${CUSTOM_EEPROM_CONFIG}"
    . /etc/default/rpi-eeprom-update
 fi
 
@@ -115,6 +116,8 @@ prepareImage()
 
       # Apply user customisations to new EEPROM config
       if [ -f "${CUSTOM_EEPROM_CONFIG}" ]; then
+         [ shellcheck -e SC2148,SC2034 "${CUSTOM_EEPROM_CONFIG}" ] || die "Invalid custom EEPROM configuration at ${CUSTOM_EEPROM_CONFIG}"
+
          while read line; do
             field="$(echo "${line}" | cut -d'=' -f1)"
 


### PR DESCRIPTION
### Functionality/purpose
This PR extends the functionality of `rpi-eeprom-update` to support setting custom EEPROM configuration values at the point of updating firmware. This allows users to ensure that any future changes to default bootloader configuration values (as happened with `WAKE_ON_GPIO`) that need to stay the same for their particular setup do not cause any issues.

The need for this functionality arose from the change to the WAKE_ON_GPIO flag within the RPi EEPROM for improved HAT support. This prevents the pi-top [4] from being able to shut down as it uses the voltage drop on the Pi to know that the shutdown sequence had been completed.

This PR provides users of pi-top [4] to have an easy way to ensure that the `WAKE_ON_GPIO` and `POWER_OFF_ON_HALT` values on the EEPROM (and potentially others in the future) are set correctly directly from the OS. It also allows any user to set any bootloader configuration variable from the OS image.

### Methodology
This PR achieves this functionality by reading the custom EEPROM config from `/etc/default/rpi-eeprom-config`, if no file is specified in `/etc/default/rpi-eeprom-update` (via `CUSTOM_EEPROM_CONFIG`), if the file exists. This file is intended to be formatted identically to the output of `vcgencmd bootloader_config`. These values are applied to the EEPROM config to be programmed, if the user has not asked to use the defaults (using the `-d` flag).

### How this is done in the code
In the current codebase (before this PR), [fewer than 3 lines of config](https://github.com/raspberrypi/rpi-eeprom/blob/master/rpi-eeprom-update#L88) (capturing empty configs and early versions which do not have the new default value for `WAKE_ON_GPIO`) [sets `OVERWRITE_CONFIG=1`](https://github.com/raspberrypi/rpi-eeprom/blob/master/rpi-eeprom-update#L92). This would then [skip](https://github.com/raspberrypi/rpi-eeprom/blob/master/rpi-eeprom-update#L97) injecting [current config values into the EEPROM file to be installed](https://github.com/raspberrypi/rpi-eeprom/blob/master/rpi-eeprom-update#L98).

I felt that it was better, in light of the changes proposed here, to [take the 'default' EEPROM values from the firmware to be installed](https://github.com/raspberrypi/rpi-eeprom/pull/65/files#diff-86eaef688a7bf372514e072950593ed7R99), and - if the user has not opted to simply use the defaults - then [patch the values from the current config](https://github.com/raspberrypi/rpi-eeprom/pull/65/files#diff-86eaef688a7bf372514e072950593ed7R111-R115), followed by the [overrides specified in `CUSTOM_EEPROM_CONFIG`](https://github.com/raspberrypi/rpi-eeprom/pull/65/files#diff-86eaef688a7bf372514e072950593ed7R117-R137).

This felt like a cleaner approach for modifying the config to apply to the firmware file, as it more clearly captures what is happening for each use case, and simplifies extensibility.

After all of these changes have (or indeed have not) been applied, [the EEPROM configuration is then printed out to screen](https://github.com/raspberrypi/rpi-eeprom/pull/65/files#diff-86eaef688a7bf372514e072950593ed7R139-R141), to clearly show what is to be applied in the update.

One important 'caveat' is that this code will [ignore `FREEZE_VERSION` from the config file](https://github.com/raspberrypi/rpi-eeprom/pull/65/files#diff-86eaef688a7bf372514e072950593ed7R126-R128), as it doesn't make sense to install an updated firmware which _then_ locks its version. If the user does not want updates, then they should disable the auto updater systemd service.

If a field specified in the custom EEPROM config is not detected, [a warning will be printed](https://github.com/raspberrypi/rpi-eeprom/pull/65/files#diff-86eaef688a7bf372514e072950593ed7R133-R134) to notify the user that this will not be applied to the config.

### Supporting changes
#### Help text
* [Added instructions](https://github.com/raspberrypi/rpi-eeprom/pull/65/files#diff-86eaef688a7bf372514e072950593ed7R377-R382) for how to use this mechanism to help text.
* Clarified wording: ["The syntax is the same as config.txt"](https://github.com/raspberrypi/rpi-eeprom/pull/65/files#diff-86eaef688a7bf372514e072950593ed7L331-L332) - now specifically mentions that this [refers to bootloader configuration](https://github.com/raspberrypi/rpi-eeprom/pull/65/files#diff-86eaef688a7bf372514e072950593ed7R384-R385) syntax.
* Clarified wording: when `-d` is used, the "default" bootloader config that is referred to is [what is provided in the EEPROM image to be installed](https://github.com/raspberrypi/rpi-eeprom/pull/65/files#diff-86eaef688a7bf372514e072950593ed7R354).
#### Config file format checking
* ~~Use [`shellcheck`](https://github.com/raspberrypi/rpi-eeprom/pull/65/files#diff-86eaef688a7bf372514e072950593ed7R119) to check formatting of config files in `/etc/default/`~~
**~~NOTE: this adds a dependency, which may not be desirable~~**
#### Variable naming
* Rename `OVERWRITE_CONFIG` to `USE_EEPROM_INTERNAL_CONFIG`. I felt that this variable was confusingly named, so I renamed it to better capture what is happening (in my opinion).

### Other changes not directly related to the detailed functionality
(NOTE: these may be better suited for a separate PR)

* [Remove argument](https://github.com/raspberrypi/rpi-eeprom/pull/65/files#diff-86eaef688a7bf372514e072950593ed7L173-R218) from call to `prepareImage` in `applyUpdate`
* [Fix typo](https://github.com/raspberrypi/rpi-eeprom/pull/65/files#diff-86eaef688a7bf372514e072950593ed7L175-R220) in applyUpdate: `bootloaer` --> `bootloader`
* [Add double quotes](https://github.com/raspberrypi/rpi-eeprom/pull/65/files#diff-86eaef688a7bf372514e072950593ed7L599-R652) in `grep "FREEZE_VERSION=1"`
* [Fix indentation](https://github.com/raspberrypi/rpi-eeprom/pull/65/files#diff-86eaef688a7bf372514e072950593ed7L116-R174) in `applyRecoveryUpdate`
* [Remove unnecessary](https://github.com/raspberrypi/rpi-eeprom/pull/65/files#diff-86eaef688a7bf372514e072950593ed7L118) `TMP_EEPROM_IMAGE="$(mktemp)"` in `applyRecoveryUpdate` (at least, I think that this is unnecessary?)

### Possible future extensions
This could be extended to check the current bootloader configuration against the desired custom bootloader configuration, and notify the user that they may get unexpected behaviour without applying the changes to the RPi firmware. This could be useful in mass deployments where many Raspberry Pi units are used against one OS image, such as over network boot, for example.