### PR TITLE
Clarifying the Dated .bin files

### DIFF
--- a/firmware/raspberry_pi4_network_boot_beta.md
+++ b/firmware/raspberry_pi4_network_boot_beta.md
@@ -40,9 +40,11 @@ sudo echo FIRMWARE_RELEASE_STATUS="beta" > /etc/default/rpi-eeprom-update
 
 ### Configuration - Enable network boot
 Network boot is not enabled by default in the bootloader. To enable it the bootloader configuration file must be edited.
+
+**NOTE:** The `/lib/firmware...` line below ends with a date at the end of the file's name. We have a few versions of the beta bootloader in there, so make sure to select the most up-to-date version for your raspberry pi.
 ```
 # Extract the configuration file
-cp /lib/firmware/raspberrypi/bootloader/beta/pieeprom-2019-09-23.bin pieeprom.bin
+cp /lib/firmware/raspberrypi/bootloader/beta/pieeprom-$DATE.bin pieeprom.bin
 rpi-eeprom-config pieeprom.bin > bootconf.txt
 
 # Enable network boot

--- a/firmware/raspberry_pi4_network_boot_beta.md
+++ b/firmware/raspberry_pi4_network_boot_beta.md
@@ -41,10 +41,10 @@ sudo echo FIRMWARE_RELEASE_STATUS="beta" > /etc/default/rpi-eeprom-update
 ### Configuration - Enable network boot
 Network boot is not enabled by default in the bootloader. To enable it the bootloader configuration file must be edited.
 
-**NOTE:** The `/lib/firmware...` line below ends with a date at the end of the file's name. There are several versions of the beta bootloader in there, so make sure to select the most up-to-date version for your Raspberry Pi.
+**NOTE:** The `/lib/firmware...` file listed in the code block below should not be copied directly, as it requires a date be maually used. There are several versions of the beta bootloader inside that directory, so make sure to select the most up-to-date version for your Raspberry Pi.
 ```
 # Extract the configuration file
-cp /lib/firmware/raspberrypi/bootloader/beta/pieeprom-$DATE.bin pieeprom.bin
+cp /lib/firmware/raspberrypi/bootloader/beta/pieeprom-YYYY-MM-DD.bin pieeprom.bin
 rpi-eeprom-config pieeprom.bin > bootconf.txt
 
 # Enable network boot

--- a/firmware/raspberry_pi4_network_boot_beta.md
+++ b/firmware/raspberry_pi4_network_boot_beta.md
@@ -41,7 +41,7 @@ sudo echo FIRMWARE_RELEASE_STATUS="beta" > /etc/default/rpi-eeprom-update
 ### Configuration - Enable network boot
 Network boot is not enabled by default in the bootloader. To enable it the bootloader configuration file must be edited.
 
-**NOTE:** The `/lib/firmware...` line below ends with a date at the end of the file's name. We have a few versions of the beta bootloader in there, so make sure to select the most up-to-date version for your raspberry pi.
+**NOTE:** The `/lib/firmware...` line below ends with a date at the end of the file's name. There are several versions of the beta bootloader in there, so make sure to select the most up-to-date version for your Raspberry Pi.
 ```
 # Extract the configuration file
 cp /lib/firmware/raspberrypi/bootloader/beta/pieeprom-$DATE.bin pieeprom.bin


### PR DESCRIPTION
Added extra clarification for the beta `.bin` file, removing the static date from the command, as plenty of people would definitely copy/paste that blindly without realizing there are multiple versions in that directory. (Me being one of those people)