### PR TITLE
rpi-eeprom-update: Remove dependency on vl805

### DIFF
--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -262,10 +262,6 @@ checkDependencies() {
       FIRMWARE_IMAGE_DIR="${FIRMWARE_IMAGE_DIR}-${BOARD_REVISION}"
    fi
 
-   if ! command -v vl805 > /dev/null; then
-      die "vl805 command not found. On Debian, try reinstalling the rpi-eeprom package."
-   fi
-
    if vcgencmd bootloader_config | grep -qi "Command not registered"; then
       die "vcgencmd: 'bootloader_config' command not supported. Please update VC firmware and reboot."
    fi


### PR DESCRIPTION
The vl805 utility is not available for aarch64 and is deprecated
because it's only required for USE_FLASHROM.

Remove the dependency check so that it can be removed from the package.

The USE_FLASHROM code will be removed at a later date once the
self-update mechanism in the bootloader EEPROM is released.