### PR TITLE
Allow for run from local git checkout

### DIFF
--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -10,7 +10,19 @@ if [ -f /etc/default/rpi-eeprom-update ]; then
    . /etc/default/rpi-eeprom-update
 fi
 
-FIRMWARE_ROOT=${FIRMWARE_ROOT:-/lib/firmware/raspberrypi/bootloader}
+LOCAL_MODE=0
+if [ -n "$FIRMWARE_ROOT" ]; then
+   # Provided by environment
+   true
+elif [ -d /lib/firmware/raspberrypi/bootloader ]; then
+   # Default firmware root exists
+   FIRMWARE_ROOT=/lib/firmware/raspberrypi/bootloader
+else
+   # Work from local git checkout
+   LOCAL_MODE=1
+   FIRMWARE_ROOT="${script_dir}/firmware"
+fi
+
 # May be used to select beta or stable releases instead of the default critical updates.
 FIRMWARE_RELEASE_STATUS=${FIRMWARE_RELEASE_STATUS:-critical}
 FIRMWARE_IMAGE_DIR=${FIRMWARE_IMAGE_DIR:-${FIRMWARE_ROOT}/${FIRMWARE_RELEASE_STATUS}}
@@ -598,7 +610,7 @@ AUTO_UPDATE_BOOTLOADER=0
 AUTO_UPDATE_VL805=0
 MACHINE_OUTPUT=""
 JSON_OUTPUT="no"
-IGNORE_DPKG_CHECKSUMS=0
+IGNORE_DPKG_CHECKSUMS=$LOCAL_MODE
 
 while getopts A:adhif:m:ju:r option; do
    case "${option}" in


### PR DESCRIPTION
This patch allows `rpi-eeprom-update` to fall back to the firmware/ directory in the same directory as `rpi-eeprom-update`, if all else fails.  Good for running directly from the git checkout, as the repo doesn't have an install target by itself and mostly assumes being part of a .deb.