### PR TITLE
rpi-eeprom-config: Pi 4B -> Pi 4

### DIFF
--- a/rpi-eeprom-config
+++ b/rpi-eeprom-config
@@ -2,7 +2,7 @@
 
 # rpi-eeprom-config
 # Utility for reading and writing the configuration file in the
-# Raspberry Pi4 bootloader EEPROM image.
+# Raspberry Pi 4 bootloader EEPROM image.
 
 import argparse
 import struct
@@ -98,7 +98,7 @@ class BootloaderImage(object):
 
 def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, \
-    description='Bootloader EEPROM configuration tool for the Raspberry Pi 4B. \
+    description='Bootloader EEPROM configuration tool for the Raspberry Pi 4. \
 \n\nThere are 3 operating modes: \
 \n\n1. Output the bootloader configuration stored in an EEPROM image file to \
 the screen (STDOUT): specify only the name of an EEPROM image file using the \


### PR DESCRIPTION
There's a CM4 on the way at some point in the future, so change reference in usage text to Pi 4B to Pi 4 instead. (Assumes CM4 has a bootloader EEPROM chip).