### PR TITLE
rpi-eeprom-update - fix description of -d flag

### DIFF
--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -358,9 +358,9 @@ Options:
    -a Automatically install bootloader and USB (VLI) EEPROM updates.
    -A Specify which type of EEPROM to automatically update (vl805 or bootloader)
    -d Use the default bootloader config, or if a file is specified using the -f
-      flag use the config in that file. This option only applies in the case of
-      a bootloader EEPROM update - it has no effect when there is no update
-      needed.
+      flag use the config in that file. This option only applies when a
+      bootloader EEPROM update is needed; if the bootloader EEPROM is up-to-date
+      then its config will not be changed.
    -f Install the given file instead of the latest applicable update
       Ignores the FREEZE_VERSION flag in bootloader and is intended for manual
       firmware updates.

--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -351,10 +351,14 @@ in /etc/default/rpi-eeprom-update by defining the BOOTFS variable.
 A backup of the current EEPROM config file is written to ${FIRMWARE_BACKUP_DIR}
 before applying the update.
 
+Unless the -d flag is specified, the current bootloader configuration is
+retained.
+
 Options:
    -a Automatically install bootloader and USB (VLI) EEPROM updates.
    -A Specify which type of EEPROM to automatically update (vl805 or bootloader)
-   -d Use the default bootloader config instead of migrating the current settings
+   -d Use the default bootloader config, or if a file is specified using the -f
+      flag use the config in that file.
    -f Install the given file instead of the latest applicable update
       Ignores the FREEZE_VERSION flag in bootloader and is intended for manual
       firmware updates.

--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -358,7 +358,9 @@ Options:
    -a Automatically install bootloader and USB (VLI) EEPROM updates.
    -A Specify which type of EEPROM to automatically update (vl805 or bootloader)
    -d Use the default bootloader config, or if a file is specified using the -f
-      flag use the config in that file.
+      flag use the config in that file. This option only applies in the case of
+      a bootloader EEPROM update - it has no effect when there is no update
+      needed.
    -f Install the given file instead of the latest applicable update
       Ignores the FREEZE_VERSION flag in bootloader and is intended for manual
       firmware updates.


### PR DESCRIPTION
The -d option has two meanings - it will, as described, insert the default configuration into the new EEPROM image if no file is specified. But it also has the as-yet-undocumented meaning of using the configuration contained in any file specified using the -f flag, rather than migrating the current config. This PR documents this second meaning.