### PR TITLE
Query checksums from rpi-eeprom instead of rpi-eeprom-images

### DIFF
--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -176,7 +176,7 @@ applyRecoveryUpdate()
 }
 
 applyUpdate() {
-   checksums_file="/var/lib/dpkg/info/rpi-eeprom-images.md5sums"
+   checksums_file="/var/lib/dpkg/info/rpi-eeprom.md5sums"
 
    [ "$(id -u)" = "0" ] || die "* Must be run as root - try 'sudo rpi-eeprom-update'"
 
@@ -185,7 +185,7 @@ applyUpdate() {
          cd /
          if ! md5sum -c "${checksums_file}" > /dev/null 2>&1; then
             md5sum -c "${checksums_file}"
-            die "rpi-eeprom-images checksums failed - try reinstalling this package"
+            die "rpi-eeprom checksums failed - try reinstalling this package"
          fi
       )
    fi


### PR DESCRIPTION
I've been putting together an Ubuntu package for rpi-eeprom and noticed in rpi-eeprom-update that it queries the now deprecated rpi-eeprom-images package, instead of rpi-eeprom. I'm assuming this needs correcting now that rpi-eeprom-images is effectively empty?