### PR TITLE
Use /usr/bin/env python to make rpi-eeprom-config more portable

### DIFF
--- a/rpi-eeprom-config
+++ b/rpi-eeprom-config
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # rpi-eeprom-config
 # Utility for reading and writing the configuration file in the


### PR DESCRIPTION
This change makes it work (at least) with NixOS out-of-the box, given that Python is installed in the environment.