### PR TITLE
Hack: detect right python version

### DIFF
--- a/rpi-eeprom-config
+++ b/rpi-eeprom-config
@@ -1,4 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/sh
+
+'''which' python > /dev/null && exec python "$0" "$@" || exec python3 "$0" "$@"
+ '''
 
 # rpi-eeprom-config
 # Utility for reading and writing the configuration file in the


### PR DESCRIPTION
This is both valid shell and python, if you execute this script, it uses a shell to detect if `python` or `python3` is available, then executes itself with python.