### PR TITLE
Use python3 in debian package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: rpi-eeprom
 Section: misc
 Priority: optional
 Maintainer: Serge Schneider <serge@raspberrypi.org>
-Build-Depends: debhelper (>= 11), help2man, python-minimal
+Build-Depends: debhelper (>= 11), help2man, python3-minimal
 Standards-Version: 4.1.3
 Homepage: https://github.com/raspberrypi/rpi-eeprom/
 Vcs-Browser: https://github.com/raspberrypi/rpi-eeprom/
@@ -11,7 +11,7 @@ Vcs-Git: https://github.com/raspberrypi/rpi-eeprom.git
 Package: rpi-eeprom
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, rpi-eeprom-images, libraspberrypi-bin,
- python, binutils, raspberrypi-bootloader (>= 1.20190819), pciutils
+ python3, binutils, raspberrypi-bootloader (>= 1.20190819), pciutils
 Breaks: rpi-eeprom-images (<<7.2)
 Replaces: rpi-eeprom-images (<<7.2)
 Recommends: flashrom

--- a/rpi-eeprom-config
+++ b/rpi-eeprom-config
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # rpi-eeprom-config
 # Utility for reading and writing the configuration file in the


### PR DESCRIPTION
Keeping compatibility with Python 2 shebang in master for any other distribution system like LibreELEC but forcing python3 in debian branch makes some space in Raspbian/Raspberry Pi OS when installing it packaged by avoiding Python 2 dependency.

Replaces python-minimal and python dependencies with Python 3 versions (which are already installed in Raspbian/Raspberry Pi OS).