### PR TITLE
Fix #211 - hexdump error on older Pi models

### DIFF
--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -268,7 +268,7 @@ getBootloaderUpdateVersion() {
 }
 
 checkDependencies() {
-   BOARD_INFO="$(hexdump -e '1/1 "%02x"' /sys/firmware/devicetree/base/system/linux,revision)"
+   BOARD_INFO="$(hexdump -ve '1/1 "%02x"' /sys/firmware/devicetree/base/system/linux,revision)"
    if [ $(((0x$BOARD_INFO >> 23) & 1)) -ne 0 ] && [ $(((0x$BOARD_INFO >> 12) & 15)) -eq 3 ]; then
       echo "BCM2711 detected"
    else


### PR DESCRIPTION
Bug fix for Raspberry Pis with low BOARD_INFO numbers. Tell hexdump to display all input data with `-v` so that zeros don't get mangled.