### PR TITLE
rpi-eeprom-update: avoid any possible od accidents

### DIFF
--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -268,7 +268,7 @@ getBootloaderUpdateVersion() {
 }
 
 checkDependencies() {
-   BOARD_INFO="$(od -An -t x1 /sys/firmware/devicetree/base/system/linux,revision | tr -d ' ')"
+   BOARD_INFO="$(od -v -An -t x1 /sys/firmware/devicetree/base/system/linux,revision | tr -d ' \n')"
    if [ $(((0x$BOARD_INFO >> 23) & 1)) -ne 0 ] && [ $(((0x$BOARD_INFO >> 12) & 15)) -eq 3 ]; then
       echo "BCM2711 detected"
    else


### PR DESCRIPTION
```
This command pipeline:

  printf '00000000000000000000000000000000' | od -An -t x1 | tr -d ' '

produces this output:

  30303030303030303030303030303030
  *

Add a `-v` to od and a `\n` to the tr arg like so:

  printf '00000000000000000000000000000000' | od -v -An -t x1 | tr -d ' \n'

to instead produce this output:

  3030303030303030303030303030303030303030303030303030303030303030

Although it's unlikely that the revision value would generate multiple
lines or contain duplicate lines, it's better to be safe than sorry
especially since the changes to do so do not introduce any extra overhead
and use only POSIX-specified options/arguments.

It's also possible this code fragment could be copied and pasted elsewhere
to provide a "hexdump" of something that might be expected to generate
multiple lines and which may potentially contain duplicates.  By fixing
the code here any breakage caused by such copying and pasting is avoided.
```