### PR TITLE
Fix package architecture

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Vcs-Browser: https://github.com/raspberrypi/rpi-eeprom/
 Vcs-Git: https://github.com/raspberrypi/rpi-eeprom.git
 
 Package: rpi-eeprom
-Architecture: all
+Architecture: armhf arm64
 Depends: ${shlibs:Depends}, ${misc:Depends}, libraspberrypi-bin, python3,
  binutils, raspberrypi-bootloader (>= 1.20190819), pciutils
 Breaks: rpi-eeprom-images (<<7.2)
@@ -21,7 +21,7 @@ Description: Raspberry Pi 4 boot EEPROM updater
  the EEPROM.
 
 Package: rpi-eeprom-images
-Architecture: all
+Architecture: armhf arm64
 Depends: ${misc:Depends}, rpi-eeprom (>=7.2)
 Priority: optional
 Section: oldlibs


### PR DESCRIPTION
Canonical have discovered an issue with the rpi-eeprom package: the package architecture is set to `all` - it should be `armhf arm64` - see https://bugs.launchpad.net/ubuntu/+bug/1884748. This PR corrects the issue here, in the upstream repo.

Rationale: the package will only work on a Raspberry Pi 4, so suggesting it works on architectures the Pi 4 doesn't use is misleading.

N.B. I have no association with Canonical - I just spotted it on their bug tracker.