### PR TITLE
rpi-eeprom-config: Properly decode configuration when extracted from …

### DIFF
--- a/rpi-eeprom-config
+++ b/rpi-eeprom-config
@@ -163,8 +163,8 @@ def read_current_config():
     nvmem_base = "/sys/bus/nvmem/devices/"
 
     if os.path.exists(fw_base + "/aliases/blconfig"):
-        with open(fw_base + "/aliases/blconfig") as f:
-            nvmem_ofnode_path = fw_base + f.read().encode('ascii')
+        with open(fw_base + "/aliases/blconfig", "rb") as f:
+            nvmem_ofnode_path = fw_base + f.read().decode('utf-8')
             for d in os.listdir(nvmem_base):
                 if os.path.realpath(nvmem_base + d + "/of_node") in os.path.normpath(nvmem_ofnode_path):
                     return (open(nvmem_base + d + "/nvmem").read(), "blconfig device")


### PR DESCRIPTION
…sysfs

The previous implementation was reading the sysfs file as plain text and
encoding it as 'ascii' to remove all the trailing zeros. This is wrong
twofold. To start with, the sysfs file we're querying is a binary
file[1], and we're reading it as a string. On top of that we're
benefiting that *some* python implementations of string.encode() will
deal with trailing zeros.

Fix this by treating the data as binary and decoding it as a string. On
top of that use 'utf-8.'

[1] sysfs files are generally text based, but there is also the option
to output binary data. Our configuration file does the later.

Signed-off-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>