### PR TITLE
rpi-eeprom-update: Use 'tr' instead of 'strings'

### DIFF
--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -113,7 +113,7 @@ getBootloaderConfig() {
    local blconfig_nvmem_path=""
 
    if [ -f "${blconfig_alias}" ]; then
-      local blconfig_ofnode_path="/sys/firmware/devicetree/base"$(strings "${blconfig_alias}")""
+      local blconfig_ofnode_path="/sys/firmware/devicetree/base"$(tr -cd [:print:] < "${blconfig_alias}")""
       local blconfig_ofnode_link=$(find -L /sys/bus/nvmem -samefile "${blconfig_ofnode_path}" 2>/dev/null)
 
       if [ -e "${blconfig_ofnode_link}" ]; then
@@ -288,7 +288,7 @@ getBootloaderUpdateVersion() {
    match=".*/pieeprom-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].bin"
    latest="$(find "${FIRMWARE_IMAGE_DIR}/" -maxdepth 1 -type f -size "${EEPROM_SIZE}c" -regex "${match}" | sort -r | head -n1)"
    if [ -f "${latest}" ]; then
-      BOOTLOADER_UPDATE_VERSION=$(strings "${latest}" | grep BUILD_TIMESTAMP | sed 's/.*=//g')
+      BOOTLOADER_UPDATE_VERSION=$(tr -c [:print:] "\n" < "${latest}" | sed '/^BUILD_TIMESTAMP=/s/.*=//p;d')
       BOOTLOADER_UPDATE_IMAGE="${latest}"
    fi
 }


### PR DESCRIPTION
The 'strings' utility is installed by binutils whereas 'tr' belongs with
coreutils. Minimal systems will only contain the latter, due to binutils'
size (20-50 MB). So, convert all uses of 'strings' to 'tr' so as to
avoid the package dependency.

The second 'tr' usage converts non-ASCII characters into newlines so as
to isolate the "BUILD_TIMESTAMP=1234567890" statement (similar to what
'strings' does). There is no need for this in the first one: non-ASCII
characters are simply discarded as DT aliases have a fixed one line
format.

Signed-off-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>