### PR TITLE
rpi-eeprom-update: Surround [:print:] with quotes

### DIFF
--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -113,7 +113,7 @@ getBootloaderConfig() {
    local blconfig_nvmem_path=""
 
    if [ -f "${blconfig_alias}" ]; then
-      local blconfig_ofnode_path="/sys/firmware/devicetree/base"$(tr -cd [:print:] < "${blconfig_alias}")""
+      local blconfig_ofnode_path="/sys/firmware/devicetree/base"$(tr -cd '[:print:]' < "${blconfig_alias}")""
       local blconfig_ofnode_link=$(find -L /sys/bus/nvmem -samefile "${blconfig_ofnode_path}" 2>/dev/null)
 
       if [ -e "${blconfig_ofnode_link}" ]; then
@@ -288,7 +288,7 @@ getBootloaderUpdateVersion() {
    match=".*/pieeprom-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].bin"
    latest="$(find "${FIRMWARE_IMAGE_DIR}/" -maxdepth 1 -type f -size "${EEPROM_SIZE}c" -regex "${match}" | sort -r | head -n1)"
    if [ -f "${latest}" ]; then
-      BOOTLOADER_UPDATE_VERSION=$(tr -c [:print:] "\n" < "${latest}" | sed '/^BUILD_TIMESTAMP=/s/.*=//p;d')
+      BOOTLOADER_UPDATE_VERSION=$(tr -c '[:print:]' "\n" < "${latest}" | sed '/^BUILD_TIMESTAMP=/s/.*=//p;d')
       BOOTLOADER_UPDATE_IMAGE="${latest}"
    fi
 }


### PR DESCRIPTION
It seems that [:print:] could be substituted by rogue shells[1], so
surround it with quotes to make sure it doesn't happen. Use single
quotes as they are the most constraining kind. All in all, this change
should be harmless.

Signed-off-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
[1] https://github.com/raspberrypi/rpi-eeprom/pull/298#issuecomment-784542905