### PR TITLE
Add make-beta-release as a wrapper around make-release

### DIFF
--- a/imager/make-beta-release
+++ b/imager/make-beta-release
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+
+firmware_status=beta
+firmware_dir=${script_dir}/../firmware/${firmware_status}
+pieeprom_version=$(basename $(ls ${firmware_dir}/pieeprom-*.bin | sort -V | tail -1) .bin | cut -d- -f2-5)
+vl805_version=$(basename $(ls ${firmware_dir}/vl805-*.bin | sort -V | tail -1) .bin | cut -d- -f2)
+
+${script_dir}/make-release ${firmware_status} ${pieeprom_version} ${vl805_version} "${script_dir}" ${firmware_status}_release rpi-boot-eeprom-recovery-${firmware_status}
+

--- a/imager/make-beta-release
+++ b/imager/make-beta-release
@@ -4,7 +4,7 @@ set -e
 
 script_dir=$(cd "$(dirname "$0")" && pwd)
 
-firmware_status=beta
+firmware_status=${firmware_status:-"beta"}
 firmware_dir=${script_dir}/../firmware/${firmware_status}
 pieeprom_version=$(basename $(ls ${firmware_dir}/pieeprom-*.bin | sort -V | tail -1) .bin | cut -d- -f2-5)
 vl805_version=$(basename $(ls ${firmware_dir}/vl805-*.bin | sort -V | tail -1) .bin | cut -d- -f2)


### PR DESCRIPTION
Builds `beta_release/*.zip` from the latest files found in `firmware/beta/`