### PR TITLE
Add a test to cause the script to exit cleanly on non-Pi hardware

### DIFF
--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -315,8 +315,11 @@ checkDependencies() {
       BOARD_INFO="$(od -v -An -t x1 /sys/firmware/devicetree/base/system/linux,revision | tr -d ' \n')"
    elif grep -q Revision /proc/cpuinfo; then
       BOARD_INFO="$(sed -n '/^Revision/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo)"
-   else
+   elif command -v vcgencmd > /dev/null; then
       BOARD_INFO="$(vcgencmd otp_dump | grep '30:' | sed 's/.*://')"
+   else
+      echo "No Raspberry Pi board info found"
+      exit ${EXIT_SUCCESS}
    fi
 
    if [ $(((0x$BOARD_INFO >> 23) & 1)) -eq 0 ] || [ $(((0x$BOARD_INFO >> 12) & 15)) -ne 3 ]; then


### PR DESCRIPTION
At present, the update script exits cleanly in the case it finds itself run on Pi hardware prior to the 4/CM4/400, but if installed on non-Pi hardware exits with various slightly cryptic errors (missing `vcgencmd` and some subsequent math errors from trying to bit-shift the empty `BOARD_INFO` variable).

This patch adds a similar exit to the non-Pi 4 case, with a slightly more useful message. It may seem rather academic but as rpi-eeprom is now in the Ubuntu armhf and arm64 archives it can theoretically (although not sensibly :) be installed on something like an AWS arm64 container.

It's arguable whether it should be a "clean" exit in this scenario. However, consider the example of a non-Pi system which has a "Revision" entry in `/proc/cpuinfo` (although obviously not a Pi revision). In this case, this script will currently exit cleanly stating "This tool only works with a Raspberry Pi 4". Likewise for a non-Pi board with a `linux,revision` node in its device-tree. Hence my choice to stick with the pattern and echo a message followed by a clean exit, but obviously I'm happy to revise this if wanted?