### PR TITLE
Fix URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ This repository contains the scripts and pre-compiled binaries used to create th
 Please check the Raspberry Pi [general discussion forum](https://www.raspberrypi.org/forums/viewforum.php?f=63) if you have a support question. 
 
 # Reset to factory defaults
-To reset the bootloader back to factory defaults use [Raspberry Pi Imager](https://www.raspberrypi.org/downloads/) to write an EEPROM update image to a spare SD card. Select `Misc utility images` under the `Operating System` tab.
+To reset the bootloader back to factory defaults use [Raspberry Pi Imager](https://www.raspberrypi.com/software/) to write an EEPROM update image to a spare SD card. Select `Misc utility images` under the `Operating System` tab.
 
 # Bootloader documentation
-* [The boot folder](https://www.raspberrypi.org/documentation/configuration/boot_folder.md)
-* [Config.txt boot options](https://www.raspberrypi.org/documentation/configuration/config-txt/boot.md)
-* [Bootloader EEPROM](https://www.raspberrypi.org/documentation/hardware/raspberrypi/booteeprom.md)
-* [Bootloader configuration](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2711_bootloader_config.md)
-* [Updating the Compute Module 4 bootloader](https://www.raspberrypi.org/documentation/hardware/computemodule/cm-emmc-flashing.md#cm4bootloader)
+* [The boot folder](https://www.raspberrypi.com/documentation/computers/configuration.html#the-boot-folder)
+* [Config.txt boot options](https://www.raspberrypi.com/documentation/computers/config_txt.html#boot-options)
+* [Bootloader EEPROM](https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#raspberry-pi-4-boot-eeprom)
+* [Bootloader configuration](https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#raspberry-pi-4-bootloader-configuration)
+* [Updating the Compute Module 4 bootloader](https://www.raspberrypi.com/documentation/computers/compute-module.html#cm4bootloader)
 * [Release notes](firmware/release-notes.md)
 * [Releases](releases.md)


### PR DESCRIPTION
These got broken by the recent doc update and the redirects to
raspberrypi.com don't seem to be correct