### PR TITLE
rpi-eeprom-config: require python3

### DIFF
--- a/rpi-eeprom-config
+++ b/rpi-eeprom-config
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 rpi-eeprom-config


### PR DESCRIPTION
Require python3 instead of relying on all distros including
python-is-python3 etc.

The code will still work with python2 but distros which require
python2 will need to maintain that as a downstream patch.