### PR TITLE
make-recovery-images: Build FAT32 disk-images for the imager zips

### DIFF
--- a/imager/README.txt
+++ b/imager/README.txt
@@ -8,16 +8,20 @@ This rescue image reverts the bootloader EEPROM to factory default settings.
 This rescue image also updates the USB 3.0 (VL805) firmware to the latest
 version (138a1) with better full-speed Isochronous endpoint support.
 
-To re-flash the EEPROM(s)
+This easiest method for creating EEPROM rescue images or formatting sdcards
+is to use the Raspberry Pi Imager from https://raspberrypi.com/software.
+The imager provides a GUI for downloading the latest version of this rescue
+image and flashing it to a spare SD CARD.
 
-1. Unzip the contents of this zip file to a blank FAT formatted SD-CARD
-2. Power off the Raspberry Pi
-3. Insert the SD-CARD
-4. Power on Raspberry Pi
-5. Wait at least 10 seconds
+Alternatively, copy the contents of this zip file to a blank
+FAT formatted SD-CARD. The FAT partition must be < 32 GB.
 
-This easiest method for creating and formatting the SD-CARD is to use the
-Raspberry Pi Imager from https://raspberrypi.org/downloads
+To update the EEPROMs:
+
+1. Power off the Raspberry Pi
+2. Insert the SD-CARD
+3. Power on Raspberry Pi
+4. Wait at least 10 seconds
 
 If successful, the green LED light will blink rapidly (forever), otherwise
 an error pattern will be displayed.
@@ -25,4 +29,5 @@ an error pattern will be displayed.
 If a HDMI display is attached then the screen will display green for success
 or red if a failure occurs.
 
-N.B. This image is not a bootloader it simply replaces the on-board bootloader.
+The SD-CARD can now be removed and re-formatted using the Raspberry Pi Imager
+e.g. to install Raspberry Pi OS.

--- a/imager/make-recovery-images
+++ b/imager/make-recovery-images
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+set -e
+
+die() {
+   echo "$@" >&2
+   exit 1
+}
+
+cleanup() {
+   if [ -d "${TMP_DIR}" ]; then
+      rm -rf "${TMP_DIR}"
+   fi
+}
+
+trap cleanup EXIT
+
+[ "$(id -u)" = "0" ] || die "Must be run as root"
+[ -n ${SUDO_UID} ] || die "SUDO_UID not defined"
+
+mkdir -p images
+chown ${SUDO_UID} images
+for src in $(ls release); do
+   img=$(echo "${src}" | sed 's/\.zip/.img/')
+   TMP_DIR=$(mktemp -d)
+   (
+      cp "release/${src}" "${TMP_DIR}"
+      mkdir "${TMP_DIR}/files"
+      cd "${TMP_DIR}/files"
+      unzip "../${src}"
+      cd "${TMP_DIR}"
+      dd if=/dev/zero bs=1M count=40 of=temp.img
+      /sbin/sfdisk temp.img <<EOF
+label: dos
+label-id: 0x0a7b5ac5
+device: temp.img
+unit: sectors
+
+./test.img1 : start=        2048, size=       70000, type=c
+EOF
+      file temp.img
+      kpartx -lv temp.img | head -n1 | awk '{print $1}'
+      LOOP="/dev/mapper/$(kpartx -lv temp.img | head -n1 | awk '{print $1}')"
+      kpartx -av temp.img
+      /sbin/mkfs.fat -F 32 "${LOOP}"
+      mkdir fs
+      mount "${LOOP}" fs
+      cp -v files/* fs
+      sync
+      umount fs
+      kpartx -dv temp.img
+   )
+   mv "${TMP_DIR}/temp.img" "images/${img}"
+   file "images/${img}"
+   zip "images/${src}" "images/${img}"
+   rm "images/${img}"
+   chown ${SUDO_UID} "images/${src}"
+done


### PR DESCRIPTION
Create small (40MB) FAT32 images with 512 KB sectors. The aim is to have a simple, fixed format to avoid compatibility / FAT issues.