### PR TITLE
make-release: Use rpi-eeprom-digest to generate update timestamps

### DIFF
--- a/imager/make-release
+++ b/imager/make-release
@@ -38,7 +38,7 @@ gen_release() {
       "${script_dir}/../rpi-eeprom-config" \
          --config "${config}" --out pieeprom.bin \
          "${firmware_dir}/pieeprom-${pieeprom_version}.bin" || die "Failed to create updated EEPROM config with \"${config}\""
-      sha256sum pieeprom.bin | awk '{print $1}' > pieeprom.sig
+      ${script_dir}/../rpi-eeprom-digest -i pieeprom.bin -o pieeprom.sig
       echo "Creating ${out}"
       zip "${out}" *
       cleanup


### PR DESCRIPTION
Previously, the .sig would have an update timestamp of zero. Switching
to rpi-eeprom-digest is preferable because the update timestamp will
be much closer to when the image was installed.

N.B. Update-timestamp is used to track configuration changes and is
independent of the build-timestamps which are the version of the
bootloader executable.