### PR TITLE
Improve BOOTFS detection

### DIFF
--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -29,7 +29,10 @@ FIRMWARE_IMAGE_DIR=${FIRMWARE_IMAGE_DIR:-${FIRMWARE_ROOT}/${FIRMWARE_RELEASE_STA
 FIRMWARE_BACKUP_DIR=${FIRMWARE_BACKUP_DIR:-/var/lib/raspberrypi/bootloader/backup}
 ENABLE_VL805_UPDATES=${ENABLE_VL805_UPDATES:-1}
 RECOVERY_BIN=${RECOVERY_BIN:-${FIRMWARE_ROOT}/${FIRMWARE_RELEASE_STATUS}/recovery.bin}
+
 BOOTFS=${BOOTFS:-/boot}
+BOOTFS_ALTERNATIVE_PATHS="/boot/firmware"
+
 CM4_ENABLE_RPI_EEPROM_UPDATE=${CM4_ENABLE_RPI_EEPROM_UPDATE:-0}
 RPI_EEPROM_UPDATE_CONFIG_TOOL="${RPI_EEPROM_UPDATE_CONFIG_TOOL:-raspi-config}"
 
@@ -544,10 +547,20 @@ findBootFS()
       BOOTFS="${TMP_BOOTFS_MNT}"
    fi
 
+   # Some distros mount boot partition in alternative locations, e.g. Debian
+   # We can aid them by probing the most common alternative paths
+   for bootfs_alternative_path in ${BOOTFS_ALTERNATIVE_PATHS}; do
+      if [ -d "${bootfs_alternative_path}" ] && [ "$(find "${bootfs_alternative_path}" -maxdepth 1 -name "*.elf" | wc -l)" -gt 0 ]; then
+         BOOTFS="${bootfs_alternative_path}"
+
+         break
+      fi
+   done
+
    # If BOOTFS is not a directory or doesn't contain any .elf files then
    # it's probably not the boot partition.
    [ -d "${BOOTFS}" ] || die "BOOTFS: \"${BOOTFS}\" is not a directory"
-   if [ "$(find "${BOOTFS}/" -name "*.elf" | wc -l)" = 0 ]; then
+   if [ "$(find "${BOOTFS}/" -maxdepth 1 -name "*.elf" | wc -l)" = 0 ]; then
       echo "WARNING: BOOTFS: \"${BOOTFS}\" contains no .elf files. Please check boot directory"
    fi
 }
@@ -677,6 +690,7 @@ removePreviousUpdates()
 {
    if [ "$(id -u)" = "0" ]; then
       findBootFS
+      echo "    BOOTFS: ${BOOTFS}"
 
       (
          # Remove any stale recovery.bin files or EEPROM images

--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -690,7 +690,7 @@ removePreviousUpdates()
 {
    if [ "$(id -u)" = "0" ]; then
       findBootFS
-      echo "    BOOTFS: ${BOOTFS}"
+      echo "BOOTFS: ${BOOTFS}"
 
       (
          # Remove any stale recovery.bin files or EEPROM images

--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -30,8 +30,10 @@ FIRMWARE_BACKUP_DIR=${FIRMWARE_BACKUP_DIR:-/var/lib/raspberrypi/bootloader/backu
 ENABLE_VL805_UPDATES=${ENABLE_VL805_UPDATES:-1}
 RECOVERY_BIN=${RECOVERY_BIN:-${FIRMWARE_ROOT}/${FIRMWARE_RELEASE_STATUS}/recovery.bin}
 
-BOOTFS=${BOOTFS:-/boot}
-BOOTFS_ALTERNATIVE_PATHS="/boot/firmware"
+if [ -z "${BOOTFS}" ]; then
+   BOOTFS="/boot"
+   BOOTFS_ALTERNATIVE_PATHS="/boot/firmware"
+fi
 
 CM4_ENABLE_RPI_EEPROM_UPDATE=${CM4_ENABLE_RPI_EEPROM_UPDATE:-0}
 RPI_EEPROM_UPDATE_CONFIG_TOOL="${RPI_EEPROM_UPDATE_CONFIG_TOOL:-raspi-config}"
@@ -549,13 +551,15 @@ findBootFS()
 
    # Some distros mount boot partition in alternative locations, e.g. Debian
    # We can aid them by probing the most common alternative paths
-   for bootfs_alternative_path in ${BOOTFS_ALTERNATIVE_PATHS}; do
-      if [ -d "${bootfs_alternative_path}" ] && [ "$(find "${bootfs_alternative_path}" -maxdepth 1 -name "*.elf" | wc -l)" -gt 0 ]; then
-         BOOTFS="${bootfs_alternative_path}"
+   if [ -n "${BOOTFS_ALTERNATIVE_PATHS}" ]; then
+      for bootfs_alternative_path in ${BOOTFS_ALTERNATIVE_PATHS}; do
+         if [ -d "${bootfs_alternative_path}" ] && [ "$(find "${bootfs_alternative_path}" -maxdepth 1 -name "*.elf" | wc -l)" -gt 0 ]; then
+            BOOTFS="${bootfs_alternative_path}"
 
-         break
-      fi
-   done
+            break
+         fi
+      done
+   fi
 
    # If BOOTFS is not a directory or doesn't contain any .elf files then
    # it's probably not the boot partition.

--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -547,11 +547,9 @@ findBootFS()
       TMP_BOOTFS_MNT="$(mktemp -d)"
       mount /dev/mmcblk0p1 "${TMP_BOOTFS_MNT}"
       BOOTFS="${TMP_BOOTFS_MNT}"
-   fi
-
-   # Some distros mount boot partition in alternative locations, e.g. Debian
-   # We can aid them by probing the most common alternative paths
-   if [ -n "${BOOTFS_ALTERNATIVE_PATHS}" ]; then
+   elif [ -n "${BOOTFS_ALTERNATIVE_PATHS}" ] && ( [ ! -d "${BOOTFS}" ] || [ "$(find "${BOOTFS}" -maxdepth 1 -name "*.elf" | wc -l)" -le 0 ] ); then
+      # Some distros mount boot partition in alternative locations, e.g. Debian
+      # We can aid them by probing the most common alternative paths
       for bootfs_alternative_path in ${BOOTFS_ALTERNATIVE_PATHS}; do
          if [ -d "${bootfs_alternative_path}" ] && [ "$(find "${bootfs_alternative_path}" -maxdepth 1 -name "*.elf" | wc -l)" -gt 0 ]; then
             BOOTFS="${bootfs_alternative_path}"


### PR DESCRIPTION
This PR adds following enhancements:
- Adds probing for common, alternative `BOOTFS` mount point, `/boot/firmware` which can be found for example in Debian images for Raspberry Pi. This happens only when `BOOTFS` was not specified by the caller, and default `/boot` location doesn't contain `.elf` files.
- Improves `BOOTFS` empty warning by limiting depth to `1`. This is important, as files deeper should not be considered, even if they have appropriate extension. In my case, the warning was not triggered despite no `.elf` files in my `/boot` - this is because `find` picked files in `/boot/firmware` instead and was happy with that.
- When removing/reverting update, prints detected `BOOTFS` in similar manner as install does.

Context: I was attempting to update my RPI's bootloader today on unofficial Debian image, which mounts RPI's boot partition with `.elf` blobs under `/boot/firmware`. This obviously has failed, as `rpi-eeprom-update` assumed that the partition is available under `/boot` instead. While currently supported `BOOTFS=/boot/firmware ./rpi-eeprom-update` way of launching the script is sufficient for my use case, I came to conclusion that it shouldn't be too much of a burden to probe that location in addition to falling back to `/boot` as right now. While doing that I also found two other misc things which I fixed by the way while coding the main feature.

I coded the probing feature in a way it triggers if, and only if, `BOOTFS` was left unspecified, which still allows overriding the detection to whatever folder caller finds appropriate. The logic also triggers only if default `/boot` has no `.elf` files inside - so we can be sure that whatever we do, `/boot` is not the correct place regardless. I also made it very easy to extend for more paths in the future if need arises - as long as they don't contain spaces, we're fine maintaining POSIX `sh` compatibility.

Naturally, after those changes, `rpi-eeprom-update -b` now prints `/boot/firmware` on my machine. It also doesn't cause any regression in official images, and I don't believe somebody could accidentally run into alternative path - he'd need to have no `.elf` files in `/boot` and `.elf` files in `/boot/firmware`, you can't do it accidentally, and even if you did, then previously used `/boot` is wrong path regardless in this case.

Thank you in advance for considering those enhancements.