### PR TITLE
"[rpi-eeprom-update] Fix rpi-eeprom-config path"

### DIFF
--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -5,6 +5,7 @@
 set -e
 
 script_dir=$(cd "$(dirname "$0")" && pwd)
+rpi_eeprom_config_dir="/usr/bin"
 
 if [ -f /etc/default/rpi-eeprom-update ]; then
    . /etc/default/rpi-eeprom-update
@@ -174,7 +175,7 @@ prepareImage()
    cp -f "${BOOTLOADER_UPDATE_IMAGE}" "${TMP_EEPROM_IMAGE}"
 
    if [ "${OVERWRITE_CONFIG}" = 0 ]; then
-      "${script_dir}/rpi-eeprom-config" \
+      "${rpi_eeprom_config_dir}/rpi-eeprom-config" \
          --out "${TMP_EEPROM_IMAGE}" \
          --config "${NEW_EEPROM_CONFIG}" "${BOOTLOADER_UPDATE_IMAGE}"
    fi


### PR DESCRIPTION
For some reason, when running `sudo rpi-eeprom-update -a`, the newer available firmware is never applied even if the command doesn't return any error.

When running `sudo rpi-eeprom-config -a` in debug, `rpi-eeprom-config` command appears to not be found because the script is looking into `/home/pi` instead of `/usr/bin`.

```
+ /home/pi/rpi-eeprom-config --out /tmp/tmp.mBRSuU7naU --config /tmp/tmp.MXSyIs3I0u /lib/firmware/raspberrypi/bootloader/beta/pieeprom-2023-01-04.bin
/usr/bin/rpi-eeprom-update: line 178: /home/pi/rpi-eeprom-config: No such file or directory
```