### PR TITLE
Fix rpi-eeprom-update when using busybox find

### DIFF
--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -126,7 +126,7 @@ getBootloaderConfig() {
 
    if [ -f "${blconfig_alias}" ]; then
       local blconfig_ofnode_path="/sys/firmware/devicetree/base"$(strings "${blconfig_alias}")""
-      local blconfig_ofnode_link=$(find -L /sys/bus/nvmem -samefile "${blconfig_ofnode_path}" 2>/dev/null)
+      local blconfig_ofnode_link=$(find -L /sys/bus/nvmem -maxdepth 3 -samefile "${blconfig_ofnode_path}" 2>/dev/null)
 
       if [ -e "${blconfig_ofnode_link}" ]; then
          blconfig_nvmem_path=$(dirname "${blconfig_ofnode_link}")


### PR DESCRIPTION
Whilst working on adding support for rpi-eeprom to the meta-raspberrypi yocto layer (see https://github.com/agherzan/meta-raspberrypi/pull/1131) I found that the following logic in rpi-eeprom-update to find the nvmem path in sysfs was broken when run using busybox find.

```
   local blconfig_alias="/sys/firmware/devicetree/base/aliases/blconfig"
   local blconfig_nvmem_path=""

   if [ -f "${blconfig_alias}" ]; then
      local blconfig_ofnode_path="/sys/firmware/devicetree/base"$(strings "${blconfig_alias}")""
      local blconfig_ofnode_link=$(find -L /sys/bus/nvmem -samefile "${blconfig_ofnode_path}" 2>/dev/null)

      if [ -e "${blconfig_ofnode_link}" ]; then
         blconfig_nvmem_path=$(dirname "${blconfig_ofnode_link}")
      fi
   fi
```

gnu find 4.8.0 (from raspbian)
```
pi@raspberrypi:~$ find -L /sys/bus/nvmem/devices/ -samefile /sys/firmware/devicetree/base/reserved-memory/nvram@0
/sys/bus/nvmem/devices/rmem0/of_node
find: File system loop detected; ‘/sys/bus/nvmem/devices/rmem0/subsystem/devices’ is part of the same file system loop as ‘/sys/bus/nvmem/devices/’.
```

busybox find 1.35 (note raspbian has an earlier version which does not include -samefile)
```
root@raspberrypi4-64:~# find -L /sys/bus/nvmem/devices/ -samefile /sys/firmware/devicetree/base/reserved-memory/nvram@0
/sys/bus/nvmem/devices/rmem0/of_node
/sys/bus/nvmem/devices/rmem0/subsystem/devices/rmem0/of_node
/sys/bus/nvmem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/of_node
/sys/bus/nvmem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/of_node
/sys/bus/nvmem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/of_node
/sys/bus/nvmem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/of_node
/sys/bus/nvmem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/of_node
/sys/bus/nvmem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/of_node
/sys/bus/nvmem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/of_node
/sys/bus/nvmem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/of_node
/sys/bus/nvmem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/of_node
/sys/bus/nvmem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/of_node
/sys/bus/nvmem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/of_node
/sys/bus/nvmem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/of_node
/sys/bus/nvmem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/of_node
/sys/bus/nvmem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/of_node
/sys/bus/nvmem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/of_node
/sys/bus/nvmem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/of_node
/sys/bus/nvmem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/of_node
/sys/bus/nvmem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/of_node
find: /sys/bus/nvmem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0/subsystem/devices/rmem0: Too many levels of symbolic links
```

I admit you could argue this is a bug in busybox, however I still think fixing it here is worth it as there's not much point descending further into sysfs than necessary.

An alternative fix which would support older versions of busybox would be to open code the comparison in bash over matches to /sys/bus/nvmem/devices/*/of_node. This is a valid option however I just went for the smaller change in the end.