### PR TITLE
rpi-eeprom-update: Follow links when looking for latest EEPROM

### DIFF
--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -308,7 +308,7 @@ BOOTLOADER_UPDATE_VERSION=0
 getBootloaderUpdateVersion() {
    BOOTLOADER_UPDATE_VERSION=0
    match=".*/pieeprom-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].bin"
-   latest="$(find "${FIRMWARE_IMAGE_DIR}/" -maxdepth 1 -type f -size "${EEPROM_SIZE}c" -regex "${match}" | sort -r | head -n1)"
+   latest="$(find "${FIRMWARE_IMAGE_DIR}/" -maxdepth 1 -type f -follow -size "${EEPROM_SIZE}c" -regex "${match}" | sort -r | head -n1)"
    if [ -f "${latest}" ]; then
       BOOTLOADER_UPDATE_VERSION=$(strings "${latest}" | grep BUILD_TIMESTAMP | sed 's/.*=//g')
       BOOTLOADER_UPDATE_IMAGE="${latest}"


### PR DESCRIPTION
latest and default are links to directories, so follow them.

Before:

/usr/bin/rpi-eeprom-update
BOOTLOADER: up to date
   CURRENT: Wed Jan 11 17:40:52 UTC 2023 (1673458852)
    LATEST: Thu Jan  1 00:00:00 UTC 1970 (0)
   RELEASE: critical (/lib/firmware/raspberrypi/bootloader/critical)

After:

/usr/bin/rpi-eeprom-update
BOOTLOADER: up to date
   CURRENT: Wed Jan 11 17:40:52 UTC 2023 (1673458852)
    LATEST: Wed Jan 11 17:40:52 UTC 2023 (1673458852)
   RELEASE: critical (/lib/firmware/raspberrypi/bootloader/critical)

Signed-off-by: Ivan T. Ivanov <iivanov@suse.de>