### PR TITLE
rpi-eeprom-update: Use flashrom by default on Pi5

### DIFF
--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -397,6 +397,8 @@ checkDependencies() {
       EEPROM_SIZE=2097152
       BOOTLOADER_AUTO_UPDATE_MIN_VERSION="${BOOTLOADER_AUTO_UPDATE_MIN_VERSION:-1704470260}"
       SPIDEV=/dev/spidev10.0
+      # Default is to use flashrom if availableon BCM2712
+      RPI_EEPROM_USE_FLASHROM=${RPI_EEPROM_USE_FLASHROM:-1}
    else
       chipNotSupported
    fi


### PR DESCRIPTION
Use flashrom by default on Pi5 unless the the RPI_EEPROM_USE_FLASHROM environment variable has been set to zero OR flashrom is not available.