### PR TITLE
rpi-eeprom-config: strip flashrom warning from latest image path

### DIFF
--- a/rpi-eeprom-config
+++ b/rpi-eeprom-config
@@ -141,7 +141,7 @@ def get_latest_eeprom():
     """
     Returns the path of the latest EEPROM image file if it exists.
     """
-    latest = shell_cmd(['rpi-eeprom-update', '-l']).rstrip()
+    latest = ''.join(shell_cmd(['rpi-eeprom-update', '-l']).splitlines()[-1:]).rstrip()
     if not os.path.exists(latest):
         exit_error("EEPROM image '%s' not found" % latest)
     return latest


### PR DESCRIPTION
`rpi-eeprom-update` calls `rpi-eeprom-update -l` to find the latest EEPROM image. When `flashrom` is not installed, `rpi-eeprom-update` additionally prints a warning about this:
```
WARNING: flashrom not found. Setting RPI_EEPROM_USE_FLASHROM to 0
```
This warning is handled as part of the EEPROM image path, which hence cannot be found.

This is one quick & dirty solution: The output of `rpi-eeprom-update` is split into a list per line, and only the last line is used for the path.

There are surely better solutions, like using STDOUT only, while printing the warning to STDERR, or skipping the `flashrom` check for `rpi-eeprom-update -l`, as it is not needed to list available images, to assure it always only prints a file path and nothing else.