### PR TITLE
release-notes.md: update heading formatting for older releases

### DIFF
--- a/firmware-2712/release-notes.md
+++ b/firmware-2712/release-notes.md
@@ -28,7 +28,7 @@
 ## 2024-05-17: Ignore bootloader updates for Pi5 on Pi4 - (latest)
 * Add timestamps to UART log messages
 
-2024-05-13: Add support for NVMe boot with PCIe switches (latest)
+## 2024-05-13: Add support for NVMe boot with PCIe switches (latest)
 * Add preliminary support for booting NVMe devices behind PCIe switches.
   See: https://github.com/raspberrypi/firmware/issues/1833
 * Fix MAX_RESTARTS parameter
@@ -40,27 +40,27 @@
   See: Fixes https://github.com/raspberrypi/rpi-eeprom/issues/574
 * Pull PCIE DET_WAKE high by default on CM5
 
-2024-04-20: Fix SDRAM refesh timing (default) (automatic update)
+## 2024-04-20: Fix SDRAM refesh timing (default) (automatic update)
 * Fix a possible performance regression on Pi5.
 
-2024-04-18: Promote the 2024-04-17 release to the default release (default) (automatic update)
+## 2024-04-18: Promote the 2024-04-17 release to the default release (default) (automatic update)
 * Select pieeprom-2024-04-17.bin to be the new default release and bump the
   automatic update minimum version to this.
 
-2024-04-18: Update RP1 firmware to extend PCIe L1 entry timeout to 32 us (latest)
+## 2024-04-18: Update RP1 firmware to extend PCIe L1 entry timeout to 32 us (latest)
 * Extend PCIe L1 entry timeout to 32us
   Fix xhci soft reset on link-down
   Set useful xhci compatibility bits in GUCTL
   See https://github.com/raspberrypi/firmware/issues/1877
 
-2024-04-17: Fix TRYBOOT flag in secure-boot mode (latest)
+## 2024-04-17: Fix TRYBOOT flag in secure-boot mode (latest)
 * Fix issue that caused the TRYBOOT flag to be lost in secure-boot mode.
 * dtoverlay: Use %u when converting u32s to strings
    See: https://github.com/raspberrypi/linux/issues/6039
 * Improved debug messages for secure-boot.
 * Generate the bootloader diagnostics qrcode at run time.
 
-2024-04-05: HAT+ fixes for max-current, custom CA cert for net install and enable over-clocking to > 3GHz (latest)
+## 2024-04-05: HAT+ fixes for max-current, custom CA cert for net install and enable over-clocking to > 3GHz (latest)
 * bootloader: clock_2712: Remove restriction on arm_freq <= 3000
   See: https://github.com/raspberrypi/firmware/issues/1876
 * arm_dt: Update max_current to match HAT value
@@ -78,7 +78,7 @@
 * Preliminary support for secure-boot OTP provisioning.
 * Update PCIE DET_WAKE pinmux for D0 products
 
-2024-02-16: u-boot loading and thermal throttling fixes (latest) (default)
+## 2024-02-16: u-boot loading and thermal throttling fixes (latest) (default)
 * arm_loader: Move non-kernels back to 512KB
   See: https://github.com/raspberrypi/firmware/issues/1868
 
@@ -86,26 +86,26 @@
   config.txt frequency.
   See: https://github.com/raspberrypi/rpi-eeprom/issues/518
 
-2024-02-14: Fix vcgencmd otp_dump and implement C(initial_turbo) (latest)
+## 2024-02-14: Fix vcgencmd otp_dump and implement C(initial_turbo) (latest)
 * Fix a regression that caused vcgencmd otp_dump to fail.
 * Implement C(initial_turbo) on Pi5
   See: https://github.com/raspberrypi/firmware/issues/1864
 
-2024-02-08: Adjust SDRAM refresh based on temperature (latest)
+## 2024-02-08: Adjust SDRAM refresh based on temperature (latest)
 
 * Adjust the SDRAM refresh interval based on the temperature. This
   addresses the gap in performance between the 8GB and 4GB variants.
   See https://github.com/raspberrypi/firmware/issues/1854
 * Preliminary support for signed boot.
 
-2024-02-05: Add support for HAT+ POE HATs (latest)
+## 2024-02-05: Add support for HAT+ POE HATs (latest)
 * Add support for probing HAT+ POE HATs
 * Implement DWC3 specific XHCI quirks
 
-2024-01-24: NVMe boot fix for WD NVMe (latest)
+## 2024-01-24: NVMe boot fix for WD NVMe (latest)
 * Add a workaround for an issue seen when booting with WD Blue SN550 NVMe SSD
 
-2024-01-22: Add support for network-install (latest)
+## 2024-01-22: Add support for network-install (latest)
 * Fix issue boot.img end sector check - STABLE
   See:  https://github.com/raspberrypi/rpi-eeprom/issues/521
 * Fix handling of files that use the last cluster in the partition
@@ -113,7 +113,7 @@
 * Fix SD card detection
   See: https://github.com/raspberrypi/rpi-eeprom/issues/523
 
-2024-01-15: Add support for network-install (latest)
+## 2024-01-15: Add support for network-install (latest)
 * Add support for Network Install
 * Preliminary D0 firmware support
 


### PR DESCRIPTION
Notes for new releases have level 2 heading markup: extend this to older releases as well, to make things a bit more readable for older releases.