### PR TITLE
BCM2712 release-notes.md - correct notes for most recent 2 releases

### DIFF
--- a/firmware-2712/release-notes.md
+++ b/firmware-2712/release-notes.md
@@ -1,6 +1,6 @@
 # Raspberry Pi5 bootloader EEPROM release notes
 
-## 2024-07-30: Optimized SDRAM timings for Pi5 8GB (default)
+## 2024-07-30: Optimized SDRAM timings for Pi5 8GB (latest)
 * Optimize all-banks/per-bank refresh timings for Pi5 8GB
 * Improve compatibility for booting from some USB SD card readers
     https://github.com/raspberrypi/rpi-eeprom/issues/527
@@ -9,7 +9,7 @@
   Also requires pciex4_reset=0 in config.txt
   earlycon=pl011,0x1f00030000,115200n8
 
-## 2024-07-25: Support CM4 nEXTRST on CM5
+## 2024-07-25: Support CM4 nEXTRST on CM5 (latest)
 * Drive nEXTRST on CM5 for CM4IO compatibility.
 * Preliminary changes for CM5 Lite.
 


### PR DESCRIPTION
- 2024-07-30 is marked `default` here, but the image is actually in the `latest` directory - fix that

- 2024-07-25 doesn't specify default or latest - fix that

(Aside: neither seem to have found their way to apt yet).