### PR TITLE
rpi-eeprom-config: Increase the timeout for flashrom shell-cmd

### DIFF
--- a/rpi-eeprom-config
+++ b/rpi-eeprom-config
@@ -180,7 +180,7 @@ def apply_update(config, eeprom=None, config_src=None):
 
     # If flashrom is used then the command will not return until the EEPROM
     # has been updated so use a larger timeout.
-    shell_cmd(args, timeout=20, echo=True)
+    shell_cmd(args, timeout=60, echo=True)
 
 def edit_config(eeprom=None):
     """


### PR DESCRIPTION
20 seconds is a little too short for safety with flashrom if every page has to be erased and re-written. Bump this to 60 seconds which is probably too long but nothing good will come from interrupting flashrom.