### PR TITLE
rpi-eeprom-config: Improve No space available error message

### DIFF
--- a/rpi-eeprom-config
+++ b/rpi-eeprom-config
@@ -346,7 +346,7 @@ class BootloaderImage(object):
             update_len = len(src_bytes) + FILE_HDR_LEN
 
             if hdr_offset + update_len > self._image_size - ERASE_ALIGN_SIZE:
-                raise Exception('No space available - image past EOF.')
+                raise Exception('No space available. %s size %d available space %d' % (dst_filename, update_len, self._image_size - ERASE_ALIGN_SIZE - hdr_offset))
 
             if hdr_offset < 0:
                 raise Exception('Update target %s not found' % dst_filename)


### PR DESCRIPTION
Improve the error handler for the case where the new EEPROM config exceeds the amount of available free space. Display the filename, new size and space available.

N.B The 2711/pieeprom-2025-08-13.bin restores the free space to a little of 4KB again.

See: https://github.com/raspberrypi/rpi-eeprom/issues/732