### PR TITLE
Fix the error message for config signing

### DIFF
--- a/rpi-eeprom-config
+++ b/rpi-eeprom-config
@@ -260,8 +260,8 @@ class BootloaderImage(object):
 
         self._image_size = len(self._bytes)
         if self._image_size not in VALID_IMAGE_SIZES:
-            exit_error("%s: Expected size %d bytes actual size %d bytes" %
-                       (filename, self._image_size, len(self._bytes)))
+            exit_error("%s: Expected sizes %s bytes, got actual size %d bytes" %
+                       (filename, VALID_IMAGE_SIZES, self._image_size))
         self.parse()
 
     def parse(self):


### PR DESCRIPTION
When the user runs rpi-eeprom-config to sign a bootloader image, if the image is not the correct size, the error message returns a tautology:

```
rpi-eeprom-config -c boot.conf -p /tmp/rpi-pubkey.pem -o pieeprom.upd /tmp/downloaded-boot.img
ERROR: /tmp/downloaded-boot.img: Expected size 62914560 bytes actual size 62914560 bytes
```

When it should be alerting the user that there are only two valid values for a bootloader size.  My MR addresses this issue by returning the acceptable values for the bootloader size in the image.

```
./rpi-eeprom-config -c boot.conf -p /tmp/rpi-pubkey.pem  -o pieeprom.upd /tmp/downloaded-boot.img
ERROR: /tmp/downloaded-boot.img: Expected sizes [524288, 2097152] bytes, got actual size 62914560 bytes
```