### PR TITLE
imager: Delete temporary release-2711, release-2712 directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.swp
+images-2711/
+images-2712/

--- a/imager/make-imager-release
+++ b/imager/make-imager-release
@@ -9,3 +9,10 @@ ${script_dir}/make-release critical 2025-11-05 000138c0 "${script_dir}/2711-conf
 
 # Pi5
 ${script_dir}/make-release critical 2025-11-05 "" "${script_dir}/2712-config" release-2712 rpi-boot-eeprom-recovery 2712
+
+# Convert to disk image for RPi Imager downloads
+sudo ${script_dir}/make-recovery-images
+
+# Delete the plain .zip files. These should not be uploaded as releases.
+rm -rf release-2711
+rm -rf release-2712


### PR DESCRIPTION
Update make-imager-release to remove the release-CHIP directories which contain the plain .zip files. These are used as the input to make-recovery-images which are disk images.
RPi Imager expects to download disk-images rather than .zips so remove the temporary directories to avoid confusion.

See: https://github.com/raspberrypi/rpi-eeprom/issues/770