### PR TITLE
rpi-eeprom-update: add CM4S (board_type 21) support

### DIFF
--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -466,7 +466,7 @@ checkDependencies() {
       echo "Run with -h for more information."
       echo
       echo "To enable flashrom programming of the EEPROM"
-      echo "Add these the following entries to /etc/default/rpi-eeprom-update"
+      echo "Add the following entries to /etc/default/rpi-eeprom-update"
       echo "RPI_EEPROM_USE_FLASHROM=1"
       echo "CM4_ENABLE_RPI_EEPROM_UPDATE=1"
       echo


### PR DESCRIPTION
Extend the CM4 EEPROM update guard to also cover CM4S. CM4S additionally requires dtparam=enable_eeprom=on under [cm4s] in config.txt to enable access to the onboard bootloader EEPROM.