### PR TITLE
rpi-eeprom-update: Check flashrom version

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ By default `rpi-eeprom-update` stages the new image to the boot partition and th
 
 ## flashrom SPI flash-chip support
 
-Before performing an immediate update, `rpi-eeprom-update` probes the SPI flash via `flashrom -p linux_spi:dev=<spidev>` and aborts back to a staged update if the probe fails or reports `Unknown flash chip`. This guards against a class of upstream bugs in `flashrom` 1.4 – 1.6 where erase operations were issued incorrectly for chips that are recognised only via SFDP, which can leave the EEPROM in a partially-erased state.
+Before performing an immediate update, `rpi-eeprom-update` probes the SPI flash via `flashrom -p linux_spi:dev=<spidev>` and aborts back to a staged update if the probe fails, or reports `Unknown flash chip` with an unpatched upstream `flashrom` 1.4 – 1.6. This guards against a class of upstream bugs in `flashrom` 1.4 – 1.6 where erase operations were issued incorrectly for chips that are recognised only via SFDP, which can leave the EEPROM in a partially-erased state.
 
 Raspberry Pi OS ships a patched downstream `flashrom` 1.4 with the SFDP erase bugs fixed. If you are running `rpi-eeprom-update` on another distribution, either use that patched build or a `flashrom` release new enough to contain the upstream fix; otherwise leave `RPI_EEPROM_IMMEDIATE_UPDATE` unset and rely on the staged update path.
 

--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -106,11 +106,15 @@ cleanup() {
       umount "${TMP_BOOTFS_MNT}"
       rmdir "${TMP_BOOTFS_MNT}"
    fi
+   if [ -f "${FLASHROM_LOG}" ]; then
+      rm -f "${FLASHROM_LOG}"
+   fi
    TMP_BOOTFS_MNT=
    TMP_EEPROM_IMAGE=
    TMP_EEPROM_CONFIG=
    NEW_EEPROM_CONFIG=
    IMMEDIATE_UPDATE_LOG=
+   FLASHROM_LOG=
 }
 trap cleanup EXIT
 
@@ -200,6 +204,29 @@ prepareImage()
          --timestamp "$(date -u +%s)" \
          "${BOOTLOADER_UPDATE_IMAGE}"
    fi
+}
+
+# upstream flashrom 1.4 - 1.6 may incorrectly erase chips when the probe
+# reports "Unknown flash chip"
+flashromUnknownFlashOk() {
+   local flashrom_line flashrom_version_str flashrom_ver flashrom_major flashrom_minor flashrom_ver_num
+
+   flashrom_line=$(head -n1 "$1")
+   flashrom_version_str=$(echo "${flashrom_line}" | sed -n 's/^flashrom \(.*\) on .*/\1/p')
+   [ -n "${flashrom_version_str}" ] || return 1
+
+   flashrom_ver=$(echo "${flashrom_version_str#v}" | sed -n 's/^\([0-9][0-9]*\)\.\([0-9][0-9]*\).*/\1 \2/p')
+   flashrom_major=${flashrom_ver%% *}
+   flashrom_minor=${flashrom_ver#* }
+   [ -n "${flashrom_major}" ] && [ -n "${flashrom_minor}" ] || return 1
+
+   flashrom_ver_num=$((flashrom_major * 100 + flashrom_minor))
+   if [ "${flashrom_ver_num}" -le 103 ] || [ "${flashrom_ver_num}" -ge 107 ]; then
+      return 0
+   fi
+
+   echo "${flashrom_version_str}" | grep -qE '^v?[0-9]+\.[0-9]+(\.[0-9]+)?-rpt'
+   return $?
 }
 
 isABCapableImage() {
@@ -441,7 +468,11 @@ applyUpdate() {
       elif ! flashrom -p linux_spi:dev=${SPIDEV},spispeed=16000 > "${FLASHROM_LOG}" 2>&1; then
          warn "WARNING: Flashrom probe of ${SPIDEV} failed"
       elif grep -q "Unknown flash" "${FLASHROM_LOG}"; then
-         warn "WARNING: Flashrom probe of ${SPIDEV} reported Unknown flash chip"
+         if flashromUnknownFlashOk "${FLASHROM_LOG}"; then
+            flashrom_probe_ok=1
+         else
+            warn "WARNING: Flashrom probe of ${SPIDEV} reported Unknown flash chip"
+         fi
       else
          flashrom_probe_ok=1
       fi


### PR DESCRIPTION
Using flashrom on an unknown flash chip is allowed if the version is <=1.3 or >=1.7 as they don't have the SFDP erase bug.