### PR TITLE
rpi-eeprom-digest: Add metadata label for the target-soc

### DIFF
--- a/imager/make-release
+++ b/imager/make-release
@@ -40,7 +40,7 @@ gen_release() {
       "${script_dir}/../rpi-eeprom-config" \
          --config "${config}" --out pieeprom.bin \
          "${firmware_dir}/pieeprom-${pieeprom_version}.bin" || die "Failed to create updated EEPROM config with \"${config}\""
-      ${script_dir}/../rpi-eeprom-digest -i pieeprom.bin -o pieeprom.sig
+      ${script_dir}/../rpi-eeprom-digest -c "${bcm_chip}" -i pieeprom.bin -o pieeprom.sig
       echo "Creating ${out}"
       zip "${out}" *
       cleanup

--- a/rpi-eeprom-digest
+++ b/rpi-eeprom-digest
@@ -58,6 +58,7 @@ https://github.com/raspberrypi/usbboot/tree/master/secure-boot-recovery/README.m
 
 
 Options:
+   -c Optional target SoC name for firmware updates (2711 or 2712).
    -i The source image, e.g., boot.img
    -o The name of the digest/signature file
    -k Optional RSA private key
@@ -112,6 +113,10 @@ writeSig() {
        echo "ts: $(date -u +%s)" >> "${OUTPUT}"
    fi
 
+   if [ -n "${TARGET_SOC}" ]; then
+       echo "target-soc: ${TARGET_SOC}" >> "${OUTPUT}"
+   fi
+
    if [ -n "${HSM_WRAPPER}" ]; then
       echo "rsa2048: $("${HSM_WRAPPER}" -a rsa2048-sha256 "${IMAGE}")" >> "${OUTPUT}"
    elif [ -n "${KEY}" ]; then
@@ -131,10 +136,13 @@ verifySig() {
    "${OPENSSL}" dgst ${ENGINE_OPTS} -verify "${KEY}" -signature "${TMP_DIR}/sig.bin" "${IMAGE}" || die "${IMAGE} not verified"
 }
 
+TARGET_SOC=""
 OUTPUT=""
 VERIFY=0
-while getopts i:H:k:ho:v: option; do
+while getopts c:i:H:k:ho:v: option; do
    case "${option}" in
+   c) TARGET_SOC="${OPTARG}"
+      ;;
    i) IMAGE="${OPTARG}"
       ;;
    k) KEY="${OPTARG}"

--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -345,7 +345,7 @@ applyRecoveryUpdate()
         if [ "${AB_EEPROM}" -ne 1 ]; then
            # Generate a .sig file containing the sha256 hash of the EEPROM image
            # and the current timestamp.
-           rpi-eeprom-digest -i "${TMP_EEPROM_IMAGE}" -o "${BOOTFS}/pieeprom.sig"
+           rpi-eeprom-digest -c "${BCM_CHIP}" -i "${TMP_EEPROM_IMAGE}" -o "${BOOTFS}/pieeprom.sig"
 
            cp -fv "${TMP_EEPROM_IMAGE}" "${BOOTFS}/pieeprom.upd" \
                    || die "Failed to copy ${TMP_EEPROM_IMAGE} to ${BOOTFS}"


### PR DESCRIPTION
Add a metadata field to pieeprom.sig indicating the target-soc. This will allow future versions of the bootloader to skip an incompatible firmware update without reading the contents of the EEPROM image file.