### PR TITLE
imager: build rpiboot GPIO image without sudo

### DIFF
--- a/imager/README-pi4-rpiboot-gpio-sd.md
+++ b/imager/README-pi4-rpiboot-gpio-sd.md
@@ -1,0 +1,53 @@
+# Raspberry Pi 4 rpiboot GPIO SD image
+
+`make-pi4-rpiboot-gpio-sd` creates a Raspberry Pi Imager-compatible SD card
+image for programming the Raspberry Pi 4B / Pi 400 OTP field that selects an
+rpiboot GPIO. GPIO numbers are BCM GPIO numbers, not physical header pin
+numbers.
+
+Programming this setting is permanent. Once programmed, it cannot be undone or
+changed. If the selected GPIO is pulled low at power-on, the SoC boot ROM enters
+rpiboot provisioning mode.
+
+## Output format
+
+The script writes:
+
+```text
+images-2711/pi4-program-rpiboot-gpioN.zip
+```
+
+where `N` is the selected GPIO number. The zip contains a raw DOS/MBR SD card
+image with one FAT32 LBA partition. The FAT32 partition contains:
+
+* `recovery.bin`
+* `config.txt`
+
+## Usage
+
+```sh
+imager/make-pi4-rpiboot-gpio-sd <gpio_num>
+```
+
+`gpio_num` must be one of these BCM GPIO numbers:
+
+```text
+2, 4, 5, 6, 7, 8
+```
+
+The generated zip can be flashed to a spare SD card with Raspberry Pi Imager.
+
+## Dependencies
+
+On Debian or Ubuntu, install:
+
+```sh
+sudo apt install util-linux dosfstools mtools zip
+```
+
+These provide:
+
+* `sfdisk` from `util-linux`
+* `mkfs.fat` from `dosfstools`
+* `mcopy` from `mtools`
+* `zip` from `zip`

--- a/imager/make-pi4-rpiboot-gpio-sd
+++ b/imager/make-pi4-rpiboot-gpio-sd
@@ -53,6 +53,8 @@ build_image()
    img="${img}.img"
    partition_start=2048
    partition_size=524288
+   temp_disk_img="temp.img"
+   temp_partition_img="fat.img"
 
    TMP_DIR="$(mktemp -d)"
    (
@@ -67,27 +69,27 @@ EOF
       echo "Generated config.txt file"
       cat config.txt
       cd "${TMP_DIR}"
-      dd if=/dev/zero bs=1M count=258 of=temp.img > /dev/null 2>&1
-      "${SFDISK}" temp.img <<EOF
+      dd if=/dev/zero bs=1M count=258 of="${temp_disk_img}" > /dev/null 2>&1
+      "${SFDISK}" "${temp_disk_img}" <<EOF
 label: dos
 label-id: 0x0a7b5ac5
-device: temp.img
+device: ${temp_disk_img}
 unit: sectors
 
 ./test.img1 : start=        ${partition_start}, size=       ${partition_size}, type=c
 EOF
-      file temp.img
-      dd if=/dev/zero bs=512 count="${partition_size}" of=fat.img > /dev/null 2>&1
-      "${MKFS_FAT}" -F 32 -s 1 fat.img > /dev/null
-      mcopy -i fat.img -v files/* ::
-      dd if=fat.img of=temp.img bs=512 seek="${partition_start}" conv=notrunc > /dev/null 2>&1
+      file "${temp_disk_img}"
+      dd if=/dev/zero bs=512 count="${partition_size}" of="${temp_partition_img}" > /dev/null 2>&1
+      "${MKFS_FAT}" -F 32 -s 1 "${temp_partition_img}" > /dev/null
+      "${MCOPY}" -i "${temp_partition_img}" -v files/* ::
+      dd if="${temp_partition_img}" of="${temp_disk_img}" bs=512 seek="${partition_start}" conv=notrunc > /dev/null 2>&1
    )
    image_dir="images-${chip}"
    mkdir -p "${image_dir}"
-   mv "${TMP_DIR}/temp.img" "${image_dir}/${img}"
+   mv "${TMP_DIR}/${temp_disk_img}" "${image_dir}/${img}"
    file "${image_dir}/${img}"
    cd "${image_dir}"
-   zip "${zip}" "${img}"
+   "${ZIP}" "${zip}" "${img}"
    cd ..
    rm "${image_dir}/${img}"
    echo "Wrote $(pwd)/${image_dir}/${zip}"
@@ -125,11 +127,11 @@ if ! MKFS_FAT=$(command -v mkfs.fat); then
    die "mkfs.fat not found: Try installing the dosfstools package"
 fi
 
-if ! command -v mcopy > /dev/null; then
+if ! MCOPY=$(command -v mcopy); then
    die "mcopy not found: Try installing the mtools package"
 fi
 
-if ! command -v zip > /dev/null; then
+if ! ZIP=$(command -v zip); then
    die "zip not found: Try installing the zip package"
 fi
 

--- a/imager/make-pi4-rpiboot-gpio-sd
+++ b/imager/make-pi4-rpiboot-gpio-sd
@@ -19,7 +19,7 @@ cleanup() {
 usage() {
 cat <<EOF
 Usage:
-sudo $(basename $0): <gpio_num>
+$(basename "$0"): <gpio_num>
 
 	Creates an SD card image which programs the OTP on a Pi 4B or Pi 400
 	to select a GPIO on the 40-pin header for use as the rpiboot GPIO.
@@ -35,16 +35,14 @@ sudo $(basename $0): <gpio_num>
 	EEPROM, insert the card in the Raspberry Pi, power on and wait for the
 	green LED to flash.
 
-	gpio_num: Select the rpiboot GPIO number from 2,4,5,6,7 or 8.
+	gpio_num: Select the rpiboot BCM GPIO number from 2,4,5,6,7 or 8.
+
+	See imager/README-pi4-rpiboot-gpio-sd.md for dependencies and image details.
 EOF
     exit 1
 }
 
 trap cleanup EXIT
-
-[ "$(id -u)" = "0" ] || die "$(basename $0) must be run as root"
-[ -n "${SUDO_UID}" ] || die "SUDO_UID not defined"
-[ -n "${SUDO_GID}" ] || die "SUDO_GID not defined"
 
 build_image()
 {
@@ -53,6 +51,8 @@ build_image()
    img="pi4-program-rpiboot-gpio${gpio}"
    zip="${img}.zip"
    img="${img}.img"
+   partition_start=2048
+   partition_size=524288
 
    TMP_DIR="$(mktemp -d)"
    (
@@ -68,45 +68,31 @@ EOF
       cat config.txt
       cd "${TMP_DIR}"
       dd if=/dev/zero bs=1M count=258 of=temp.img > /dev/null 2>&1
-      /sbin/sfdisk temp.img <<EOF
+      "${SFDISK}" temp.img <<EOF
 label: dos
 label-id: 0x0a7b5ac5
 device: temp.img
 unit: sectors
 
-./test.img1 : start=        2048, size=       524288, type=c
+./test.img1 : start=        ${partition_start}, size=       ${partition_size}, type=c
 EOF
       file temp.img
-      LOOP="/dev/mapper/$(kpartx -lv temp.img | head -n1 | awk '{print $1}')"
-      kpartx -a temp.img
-      /sbin/mkfs.fat -F 32 -s 1 "${LOOP}" > /dev/null
-      mkdir fs
-      mount "${LOOP}" fs
-      cp -v files/* fs
-      sync
-      sleep 5
-      umount fs
-      # Delay before calling kpartx otherwise it's sometimes possible to get orphaned loopback devices
-      sleep 5
-      kpartx -d temp.img
+      dd if=/dev/zero bs=512 count="${partition_size}" of=fat.img > /dev/null 2>&1
+      "${MKFS_FAT}" -F 32 -s 1 fat.img > /dev/null
+      mcopy -i fat.img -v files/* ::
+      dd if=fat.img of=temp.img bs=512 seek="${partition_start}" conv=notrunc > /dev/null 2>&1
    )
    image_dir="images-${chip}"
    mkdir -p "${image_dir}"
-   chown "${SUDO_UID}:${SUDO_GID}" "${image_dir}"
    mv "${TMP_DIR}/temp.img" "${image_dir}/${img}"
    file "${image_dir}/${img}"
    cd "${image_dir}"
    zip "${zip}" "${img}"
    cd ..
    rm "${image_dir}/${img}"
-   chown "${SUDO_UID}:${SUDO_GID}" "${image_dir}/${zip}"
    echo "Wrote $(pwd)/${image_dir}/${zip}"
 }
 
-
-if ! command -v kpartx > /dev/null; then
-   die "kpartx not found: Try installing the kpartx package"
-fi
 
 [ -n "${1}" ] || usage
 gpio_num="$1"
@@ -130,5 +116,21 @@ case "${gpio_num}" in
   	  usage
 	  	;;
 esac
+
+if ! SFDISK=$(command -v sfdisk); then
+   die "sfdisk not found: Try installing the util-linux package"
+fi
+
+if ! MKFS_FAT=$(command -v mkfs.fat); then
+   die "mkfs.fat not found: Try installing the dosfstools package"
+fi
+
+if ! command -v mcopy > /dev/null; then
+   die "mcopy not found: Try installing the mtools package"
+fi
+
+if ! command -v zip > /dev/null; then
+   die "zip not found: Try installing the zip package"
+fi
 
 build_image 2711 "${gpio_num}"


### PR DESCRIPTION
## Summary

`imager/make-pi4-rpiboot-gpio-sd` currently requires root because it uses
`kpartx`, `/dev/mapper`, `mkfs.fat` on a mapped block device, and `mount` to
populate the FAT partition.

This changes the script to build the same raw SD card image entirely as regular
files without sudo:

- create the DOS/MBR image with `sfdisk`
- create a partition-sized FAT32 image with `mkfs.fat`
- copy `recovery.bin` and `config.txt` with `mcopy`
- write the FAT image into the raw SD image at the existing partition offset
- preserve the existing `.zip` output containing the raw `.img`

It also adds README documentation for the helper, including usage, image format,
valid BCM GPIO values, and Debian/Ubuntu dependencies.

## Testing

- Ran `git diff --check`
- Verified usage output for missing arguments
- Verified invalid GPIO handling
- Built an image as a non-root user
- Confirmed the generated zip contains the raw `.img`