### PR TITLE
rpi-eeprom-digest: Bubble errors from HSM_WRAPPER invocation

### DIFF
--- a/rpi-eeprom-digest
+++ b/rpi-eeprom-digest
@@ -118,10 +118,12 @@ writeSig() {
    fi
 
    if [ -n "${HSM_WRAPPER}" ]; then
-      echo "rsa2048: $("${HSM_WRAPPER}" -a rsa2048-sha256 "${IMAGE}")" >> "${OUTPUT}"
+      sig_hex="$("${HSM_WRAPPER}" -a rsa2048-sha256 "${IMAGE}")"
+      echo "rsa2048: ${sig_hex}" >> "${OUTPUT}"
    elif [ -n "${KEY}" ]; then
       "${OPENSSL}" dgst ${ENGINE_OPTS} -sign "${KEY}" -sha256 -out "${SIG_TMP}" "${IMAGE}"
-      echo "rsa2048: $(xxd -c 4096 -p < "${SIG_TMP}")" >> "${OUTPUT}"
+      sig_hex="$(xxd -c 4096 -p < "${SIG_TMP}")"
+      echo "rsa2048: ${sig_hex}" >> "${OUTPUT}"
    fi
 }
 


### PR DESCRIPTION
Noticed when passing a custom HSM wrapper using `-H` to `rpi-eeprom-digest`, if my wrapper would fail (exit non-zero) then `rpi-eeprom-digest` would carry on as if everything was fine and end up with an empty signature being written to `boot.sig`.

As I understand it, errors in sub-shells (`$(...)`) *inside* a command aren't bubbled up by `set -e`, even if the sub-shell fails the outer `echo` is the only thing which `set -e` takes into account. And that call succeeds, so the script reports a success.

Assigning the signature to a variable avoids this shell footgun.

This can easily be tested with a purposefully always-failing wrapper, such as this (which also logs something before exiting):

    ❯ cat /tmp/badwrapper
    #!/bin/sh
    echo "wrapper exploded" >&2
    exit 1

Before:

    ❯ ./rpi-eeprom-digest -H /tmp/badwrapper -i /tmp/p.img -o /tmp/p.sig
    wrapper exploded
    ❯ echo $?
    0
    ❯ cat /tmp/p.sig
    2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
    ts: 1786364891
    rsa2048:

After:

    ❯ ./rpi-eeprom-digest -H /tmp/badwrapper -i /tmp/p.img -o /tmp/p.sig
    wrapper exploded
    ❯ echo $?
    1
    ❯ cat /tmp/p.sig
    2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
    ts: 1786364960

(the file is still partially written, but there's not much I can do about that without a bigger change - this is still an improvement as at least the overall exit status can be relied on)