### PR TITLE
rpi-eeprom-update: Flashrom never use unknown flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ By default `rpi-eeprom-update` stages the new image to the boot partition and th
 
 ## flashrom SPI flash-chip support
 
-Before performing an immediate update, `rpi-eeprom-update` probes the SPI flash via `flashrom -p linux_spi:dev=<spidev>` and aborts back to a staged update if the probe fails, or reports `Unknown flash chip` with an unpatched upstream `flashrom` 1.4 – 1.6. This guards against a class of upstream bugs in `flashrom` 1.4 – 1.6 where erase operations were issued incorrectly for chips that are recognised only via SFDP, which can leave the EEPROM in a partially-erased state.
+Before performing an immediate update, `rpi-eeprom-update` probes the SPI flash via `flashrom -p linux_spi:dev=<spidev>` and aborts back to a staged update if the probe fails, or reports `Unknown flash chip`. Generic SFDP handling of unknown flash chips is not supported as SFDP data cannot always be trusted.
 
-Raspberry Pi OS ships a patched downstream `flashrom` 1.4 with the SFDP erase bugs fixed. If you are running `rpi-eeprom-update` on another distribution, either use that patched build or a `flashrom` release new enough to contain the upstream fix; otherwise leave `RPI_EEPROM_IMMEDIATE_UPDATE` unset and rely on the staged update path.
+Raspberry Pi OS ships a patched downstream `flashrom` 1.4 with definitions for all the different chips a Raspberry Pi could be manufactured with. If you are running `rpi-eeprom-update` on another distribution, either use that patched build or a `flashrom` release new enough to contain all the chip definitions; otherwise leave `RPI_EEPROM_IMMEDIATE_UPDATE` unset and rely on the staged update path.
 
 ## Raspberry Pi 5 / 500 / 500+ / CM5 (BCM2712)
 

--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -206,29 +206,6 @@ prepareImage()
    fi
 }
 
-# upstream flashrom 1.4 - 1.6 may incorrectly erase chips when the probe
-# reports "Unknown flash chip"
-flashromUnknownFlashOk() {
-   local flashrom_line flashrom_version_str flashrom_ver flashrom_major flashrom_minor flashrom_ver_num
-
-   flashrom_line=$(head -n1 "$1")
-   flashrom_version_str=$(echo "${flashrom_line}" | sed -n 's/^flashrom \(.*\) on .*/\1/p')
-   [ -n "${flashrom_version_str}" ] || return 1
-
-   flashrom_ver=$(echo "${flashrom_version_str#v}" | sed -n 's/^\([0-9][0-9]*\)\.\([0-9][0-9]*\).*/\1 \2/p')
-   flashrom_major=${flashrom_ver%% *}
-   flashrom_minor=${flashrom_ver#* }
-   [ -n "${flashrom_major}" ] && [ -n "${flashrom_minor}" ] || return 1
-
-   flashrom_ver_num=$((flashrom_major * 100 + flashrom_minor))
-   if [ "${flashrom_ver_num}" -le 103 ] || [ "${flashrom_ver_num}" -ge 107 ]; then
-      return 0
-   fi
-
-   echo "${flashrom_version_str}" | grep -qE '^v?[0-9]+\.[0-9]+(\.[0-9]+)?-rpt'
-   return $?
-}
-
 isABCapableImage() {
    offset=0x10008
    count=8
@@ -468,11 +445,9 @@ applyUpdate() {
       elif ! flashrom -p linux_spi:dev=${SPIDEV},spispeed=16000 > "${FLASHROM_LOG}" 2>&1; then
          warn "WARNING: Flashrom probe of ${SPIDEV} failed"
       elif grep -q "Unknown flash" "${FLASHROM_LOG}"; then
-         if flashromUnknownFlashOk "${FLASHROM_LOG}"; then
-            flashrom_probe_ok=1
-         else
-            warn "WARNING: Flashrom probe of ${SPIDEV} reported Unknown flash chip"
-         fi
+         # Generic SFDP handling is not supported because some chips have
+         # been known to have incorrect SFDP data
+         warn "WARNING: Flashrom probe of ${SPIDEV} reported Unknown flash chip"
       else
          flashrom_probe_ok=1
       fi


### PR DESCRIPTION
Flashrom should only be used if the chip is known. SFDP cannot be relied on to be correct so generic handling may not work.

See: https://github.com/raspberrypi/rpi-eeprom/issues/864