### PR TITLE
rpi-eeprom-update: Firmware downgrades now require the '-y' flag or an interactive response

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ To prevent this, the board manufacture process programs a minimum bootloader ver
 WARNING: Bootloader image version MFG_VER: <image> is older than the board manufacture version (<min>).
 ```
 
-The warning is advisory by default — the update still proceeds. Set `STRICT_MIN_VER_CHECK=1` in `/etc/default/rpi-eeprom-update` to turn this into a hard error so a downgrade onto unsupported hardware is refused rather than merely flagged. A similar check is also applied against the installed `rpi-eeprom` package version: if the package is too old for the board, `rpi-eeprom-update` prompts the user to `apt upgrade rpi-eeprom`.
+By default the update is refused. Set `STRICT_MIN_VER_CHECK=0` in `/etc/default/rpi-eeprom-update` to downgrade the error to a warning and proceed anyway. A similar check is also applied against the installed `rpi-eeprom` package version: if the package is too old for the board, `rpi-eeprom-update` prompts the user to `apt upgrade rpi-eeprom`.
 
 # Support
 Please check the Raspberry Pi [general discussion forum](https://forums.raspberrypi.com/viewforum.php?f=63) if you have a support question.

--- a/rpi-eeprom-config
+++ b/rpi-eeprom-config
@@ -122,18 +122,21 @@ def shell_cmd(args, timeout=10, echo=False):
     """
     Executes a shell command waits for completion returning STDOUT. If an
     error occurs then exit and output the subprocess stdout, stderr messages
-    for debug.
+    for debug. In echo mode stdout and stderr are passed through as they
+    arrive so the command's own errors and prompts are seen in order.
     """
     start = time.monotonic()
     arg_str = ' '.join(args)
     bufsize = 0 if echo else -1
-    result = subprocess.Popen(args, bufsize=bufsize, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    result = subprocess.Popen(args, bufsize=bufsize, stdout=subprocess.PIPE,
+                              stderr=None if echo else subprocess.PIPE)
 
     while time.monotonic() - start < timeout:
         if echo:
             s = result.stdout.read(80).decode('utf-8')
             if s != "":
                 sys.stdout.write(s)
+                sys.stdout.flush()
         if result.poll() is not None:
             break
 
@@ -143,6 +146,8 @@ def shell_cmd(args, timeout=10, echo=False):
         exit_error("%s timeout" % arg_str)
 
     if result.returncode != 0:
+        if echo:
+            exit_error("%s failed: %d" % (args[0], result.returncode))
         exit_error("%s failed: %d\n %s\n %s\n" %
                    (arg_str, result.returncode, result.stdout.read().decode('utf-8'), result.stderr.read().decode('utf-8')))
     elif not echo:

--- a/rpi-eeprom-config
+++ b/rpi-eeprom-config
@@ -643,4 +643,8 @@ See 'rpi-eeprom-update -h' for more information about the available EEPROM image
 
 if __name__ == '__main__':
     atexit.register(exit_handler)
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.stderr.write("\nInterrupted\n")
+        sys.exit(130)

--- a/rpi-eeprom-config
+++ b/rpi-eeprom-config
@@ -138,6 +138,8 @@ def shell_cmd(args, timeout=10, echo=False):
             break
 
     if result.poll() is None:
+        result.kill()
+        result.wait()
         exit_error("%s timeout" % arg_str)
 
     if result.returncode != 0:

--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -55,8 +55,6 @@ EXIT_EEPROM_FROZEN=3
 # EXIT_PREVIOUS_UPDATE_FAILED=4
 
 OVERWRITE_CONFIG=0
-# Timestamp for first release which doesn't have a timestamp field
-BOOTLOADER_FIRST_VERSION=1557513636
 EEPROM_SIZE=524288
 # BOOT_VER is checked against the manufacturing version in OTP to verify
 # that this script is new enough to correctly update the bootloader on this board.
@@ -128,7 +126,8 @@ warn() {
 }
 
 readDtInt() {
-   printf "%d" "0x$(od "$1" -v -An -t x1 | tr -d ' ')"
+   hex="$(od "$1" -v -An -t x1 | tr -d ' ')"
+   [ -z "${hex}" ] || printf "%d" "0x${hex}"
 }
 
 getBootloaderConfig() {
@@ -281,12 +280,12 @@ applyRecoveryUpdate()
 
    getBootloaderCurrentVersion
    BOOTLOADER_UPDATE_VERSION=$(strings "${BOOTLOADER_UPDATE_IMAGE}" | grep BUILD_TIMESTAMP | sed 's/.*=//g')
-   if [ "${BOOTLOADER_CURRENT_VERSION}" -gt "${BOOTLOADER_UPDATE_VERSION}" ]; then
+   if [ "${BOOTLOADER_CURRENT_VERSION:-0}" -gt "${BOOTLOADER_UPDATE_VERSION}" ]; then
       warn "   WARNING: Installing an older bootloader version."
       warn "            Update the rpi-eeprom package to fetch the latest bootloader images."
       warn
    fi
-   echo "   CURRENT: $(date -u "-d@${BOOTLOADER_CURRENT_VERSION}") (${BOOTLOADER_CURRENT_VERSION})"
+   printBootloaderCurrentVersion
    echo "    UPDATE: $(date -u "-d@${BOOTLOADER_UPDATE_VERSION}") (${BOOTLOADER_UPDATE_VERSION})"
 
    findBootFS
@@ -360,7 +359,7 @@ applyRecoveryUpdate()
       fi
    fi
 
-   [ "${BOOTLOADER_CURRENT_VERSION}" -ge "${RPI_EEPROM_SELF_UPDATE_MIN_VER}" ] || RPI_EEPROM_SELF_UPDATE=0
+   [ "${BOOTLOADER_CURRENT_VERSION:-0}" -ge "${RPI_EEPROM_SELF_UPDATE_MIN_VER}" ] || RPI_EEPROM_SELF_UPDATE=0
 
    # For immediate updates via flashrom the recovery.bin update is created and then discarded if the
    # flashrom update was successful. For SD boot (most common) this provides a rollback in the event
@@ -485,26 +484,30 @@ applyUpdate() {
    applyRecoveryUpdate
 }
 
+# Empty if the running bootloader version could not be determined.
 BOOTLOADER_CURRENT_VERSION=
 getBootloaderCurrentVersion() {
+   BOOTLOADER_CURRENT_VERSION=
    if [ -f "${DT_BOOTLOADER_TS}" ]; then
       # Prefer device-tree to vcgencmd
       BOOTLOADER_CURRENT_VERSION=$(readDtInt "${DT_BOOTLOADER_TS}")
    elif vcgencmd bootloader_version | grep -q timestamp; then
       BOOTLOADER_CURRENT_VERSION=$(vcgencmd bootloader_version | grep timestamp | awk '{print $2}')
-      if [ "${BOOTLOADER_CURRENT_VERSION}" = "0" ]; then
-         # If a timestamp of zero is returned then it's new firmware but an
-         # old bootloader. Assume bootloader v0
-         BOOTLOADER_CURRENT_VERSION="${BOOTLOADER_FIRST_VERSION}"
-      fi
    else
       # New bootloader / old firmware ? Try to parse the date
-      BOOTLOADER_CURRENT_VERSION=$(date -u +%s --date "$(vcgencmd bootloader_version | head -n1)" 2>/dev/null || true)
+      # N.B. date treats an empty string as today so check for no output first.
+      first_line="$(vcgencmd bootloader_version | head -n1)"
+      if [ -n "${first_line}" ]; then
+         BOOTLOADER_CURRENT_VERSION=$(date -u +%s --date "${first_line}" 2>/dev/null || true)
+      fi
    fi
+}
 
-   # Failed to parse the version. Default to the initial production release.
-   if [ -z "${BOOTLOADER_CURRENT_VERSION}" ]; then
-      BOOTLOADER_CURRENT_VERSION="${BOOTLOADER_FIRST_VERSION}"
+printBootloaderCurrentVersion() {
+   if [ -n "${BOOTLOADER_CURRENT_VERSION}" ]; then
+      echo "   CURRENT: $(date -u "-d@${BOOTLOADER_CURRENT_VERSION}") (${BOOTLOADER_CURRENT_VERSION})"
+   else
+      echo "   CURRENT: unknown"
    fi
 }
 
@@ -575,6 +578,7 @@ checkDependencies() {
 
    if [ -f "${DT_MIN_BOOT_VER}" ]; then
       MIN_BOOT_VER=$(readDtInt "${DT_MIN_BOOT_VER}")
+      MIN_BOOT_VER=${MIN_BOOT_VER:-0}
    fi
 
    [ "${BCM_CHIP}" = "2711" ] && pkg_boot_ver=${BOOT_VER_2711} || pkg_boot_ver=${BOOT_VER_2712}
@@ -846,7 +850,7 @@ printVersions()
       echo "BOOTLOADER: up to date"
    fi
 
-   echo "   CURRENT: $(date -u "-d@${BOOTLOADER_CURRENT_VERSION}") (${BOOTLOADER_CURRENT_VERSION})"
+   printBootloaderCurrentVersion
    echo "    LATEST: $(date -u "-d@${BOOTLOADER_UPDATE_VERSION}") (${BOOTLOADER_UPDATE_VERSION})"
    echo "   RELEASE: ${FIRMWARE_RELEASE_STATUS} (${FIRMWARE_IMAGE_DIR})"
    echo "            Use ${RPI_EEPROM_UPDATE_CONFIG_TOOL} to change the release."
@@ -956,7 +960,15 @@ lookupVersionInfo()
    ACTION_UPDATE_BOOTLOADER=0
    ACTION_UPDATE_VL805=0
 
-   if [ "${BOOTLOADER_UPDATE_VERSION}" -gt "${BOOTLOADER_CURRENT_VERSION}" ]; then
+   # Never offer an update if the running version is unknown. Anything else
+   # risks downgrading the bootloader e.g. if device-tree and vcgencmd are
+   # unavailable in a chroot.
+   if [ -z "${BOOTLOADER_CURRENT_VERSION}" ]; then
+      warn "Unable to determine the current bootloader version. Skipping bootloader update."
+      warn "Use rpi-eeprom-update -f to install a specific image."
+      warn
+      BOOTLOADER_UPDATE_IMAGE=""
+   elif [ "${BOOTLOADER_UPDATE_VERSION}" -gt "${BOOTLOADER_CURRENT_VERSION}" ]; then
       ACTION_UPDATE_BOOTLOADER=1
    else
       BOOTLOADER_UPDATE_IMAGE=""

--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -28,6 +28,8 @@ fi
 # Selects the release sub-directory
 FIRMWARE_RELEASE_STATUS=${FIRMWARE_RELEASE_STATUS:-default}
 FIRMWARE_BACKUP_DIR=${FIRMWARE_BACKUP_DIR:-/var/lib/raspberrypi/bootloader/backup}
+# Install an older bootloader without confirmation (-y)
+RPI_EEPROM_ALLOW_DOWNGRADE=${RPI_EEPROM_ALLOW_DOWNGRADE:-0}
 ENABLE_VL805_UPDATES=${ENABLE_VL805_UPDATES:-1}
 CM4_ENABLE_RPI_EEPROM_UPDATE=${CM4_ENABLE_RPI_EEPROM_UPDATE:-0}
 RPI_EEPROM_UPDATE_CONFIG_TOOL="${RPI_EEPROM_UPDATE_CONFIG_TOOL:-raspi-config}"
@@ -280,16 +282,8 @@ applyRecoveryUpdate()
 
    getBootloaderCurrentVersion
    BOOTLOADER_UPDATE_VERSION=$(strings "${BOOTLOADER_UPDATE_IMAGE}" | grep BUILD_TIMESTAMP | sed 's/.*=//g')
-   if [ "${BOOTLOADER_CURRENT_VERSION:-0}" -gt "${BOOTLOADER_UPDATE_VERSION}" ]; then
-      warn "   WARNING: Installing an older bootloader version."
-      warn "            Update the rpi-eeprom package to fetch the latest bootloader images."
-      warn
-   fi
    printBootloaderCurrentVersion
    echo "    UPDATE: $(date -u "-d@${BOOTLOADER_UPDATE_VERSION}") (${BOOTLOADER_UPDATE_VERSION})"
-
-   findBootFS
-   echo "    BOOTFS: ${BOOTFS}"
 
    # Check the minimum version programmed during board manufacture
    if [ -n "${BOOTLOADER_UPDATE_IMAGE}" ]; then
@@ -306,6 +300,11 @@ applyRecoveryUpdate()
          fi
       fi
    fi
+
+   confirmDowngrade
+
+   findBootFS
+   echo "    BOOTFS: ${BOOTFS}"
 
    if [ -n "${BOOTLOADER_UPDATE_IMAGE}" ]; then
         [ -f "${BOOTLOADER_UPDATE_IMAGE}" ] || die "${BOOTLOADER_UPDATE_IMAGE} not found"
@@ -509,6 +508,37 @@ printBootloaderCurrentVersion() {
    else
       echo "   CURRENT: unknown"
    fi
+}
+
+# Prompt before installing an older (or unknown age) bootloader
+confirmDowngrade() {
+   [ -n "${BOOTLOADER_UPDATE_IMAGE}" ] || return 0
+   if [ -n "${BOOTLOADER_CURRENT_VERSION}" ] && [ "${BOOTLOADER_UPDATE_VERSION}" -ge "${BOOTLOADER_CURRENT_VERSION}" ]; then
+      return 0
+   fi
+
+   if [ -n "${BOOTLOADER_CURRENT_VERSION}" ]; then
+      warn "   WARNING: Installing an older bootloader version."
+      warn "            Update the rpi-eeprom package to fetch the latest bootloader images."
+   else
+      warn "   WARNING: The current bootloader version is unknown so this may be a downgrade."
+   fi
+   warn
+   [ "${RPI_EEPROM_ALLOW_DOWNGRADE}" = 1 ] && return 0
+
+   # Callers such as rpi-eeprom-config redirect stdout so use the tty
+   if ! ( : < /dev/tty ) 2> /dev/null; then
+      die "Bootloader downgrade refused. Use -y or set RPI_EEPROM_ALLOW_DOWNGRADE=1 in /etc/default/rpi-eeprom-update to allow this."
+   fi
+   current="unknown"
+   [ -z "${BOOTLOADER_CURRENT_VERSION}" ] || current="$(date -u "-d@${BOOTLOADER_CURRENT_VERSION}" +%F)"
+   printf "Install bootloader %s over the current version (%s)? [y/N] " \
+      "$(date -u "-d@${BOOTLOADER_UPDATE_VERSION}" +%F)" "${current}" > /dev/tty
+   read -r answer < /dev/tty || answer=
+   case "${answer}" in
+      [yY]|[yY][eE][sS]) ;;
+      *) die "Bootloader downgrade cancelled." ;;
+   esac
 }
 
 # Find latest applicable update version
@@ -740,6 +770,8 @@ Options:
       bootloader release is newer than the version specified by
       BOOTLOADER_AUTO_UPDATE_MIN_VERSION ${BOOTLOADER_AUTO_UPDATE_MIN_VERSION}
    -u Install the specified VL805 (USB EEPROM) image file.
+   -y Install an older bootloader without confirmation
+      (RPI_EEPROM_ALLOW_DOWNGRADE=1). Does not bypass the MFG_VER check.
 
 Environment:
 Environment variables should be defined in /etc/default/rpi-eeprom-update
@@ -754,6 +786,12 @@ and POWER_OFF_ON_HALT settings.
 FIRMWARE_RELEASE_STATUS
 
 Specifies the release status of the firmware to apply.
+
+RPI_EEPROM_ALLOW_DOWNGRADE
+
+Installing a bootloader older than the current version (or of unknown
+relative age) prompts for confirmation and fails without a terminal.
+Set to 1 (or pass -y) to skip the prompt.
 
 Before selecting a firmware release directory this script checks whether there
 is a board revision specific variant e.g. default-c03111. If present then the
@@ -1173,7 +1211,7 @@ if [ ! -d "${PACKAGE_INFO_DIR}" ]; then
 fi
 
 
-while getopts A:abdhilf:m:ju:rs option; do
+while getopts A:abdhilf:m:ju:rsy option; do
    case "${option}" in
    A)
       if [ "${OPTARG}" = "bootloader" ]; then
@@ -1221,6 +1259,8 @@ while getopts A:abdhilf:m:ju:rs option; do
    s) SILENT_UPDATE=1
       ;;
    u) VL805_UPDATE_IMAGE="${OPTARG}"
+      ;;
+   y) RPI_EEPROM_ALLOW_DOWNGRADE=1
       ;;
    *) echo "Unknown argument \"${option}\""
       usage

--- a/rpi-eeprom-update
+++ b/rpi-eeprom-update
@@ -47,7 +47,7 @@ RPI_EEPROM_SELF_UPDATE_MIN_VER=1650968668
 
 DT_BOOTLOADER_TS=${DT_BOOTLOADER_TS:-/proc/device-tree/chosen/bootloader/build-timestamp}
 DT_MIN_BOOT_VER=${DT_MIN_BOOT_VER:-/proc/device-tree/chosen/rpi-min-boot-ver}
-STRICT_MIN_VER_CHECK=${STRICT_MIN_VER_CHECK:-0}
+STRICT_MIN_VER_CHECK=${STRICT_MIN_VER_CHECK:-1}
 
 EXIT_SUCCESS=0
 EXIT_UPDATE_REQUIRED=1
@@ -296,7 +296,7 @@ applyRecoveryUpdate()
          warn "WARNING: Bootloader image version MFG_VER: ${image_boot_ver} is older than the board manufacture version (${MIN_BOOT_VER})."
          warn
          if [ "${STRICT_MIN_VER_CHECK}" = 1 ]; then
-            die "ERROR: Update image is not supported by this device. Exiting."
+            die "ERROR: Update image is not supported by this device. Set STRICT_MIN_VER_CHECK=0 to force the install."
          fi
       fi
    fi
@@ -792,6 +792,13 @@ RPI_EEPROM_ALLOW_DOWNGRADE
 Installing a bootloader older than the current version (or of unknown
 relative age) prompts for confirmation and fails without a terminal.
 Set to 1 (or pass -y) to skip the prompt.
+
+STRICT_MIN_VER_CHECK
+
+Images with an MFG_VER older than the board manufacture version are
+rejected. Set to 0 to warn and install anyway. The -y option does not
+override this check e.g. to force the install run:
+   sudo STRICT_MIN_VER_CHECK=0 rpi-eeprom-update -d -f pieeprom.bin -y
 
 Before selecting a firmware release directory this script checks whether there
 is a board revision specific variant e.g. default-c03111. If present then the

--- a/rpi-eeprom-update-default
+++ b/rpi-eeprom-update-default
@@ -19,3 +19,6 @@ EEPROM_CONFIG_HOOK=
 # Set STRICT_MIN_VER_CHECK to 1 to treat bootloader manufacturing min-version checks as a fatal error
 # Default is currently 0
 #STRICT_MIN_VER_CHECK=1
+
+# Set to 1 to install an older bootloader without confirmation
+#RPI_EEPROM_ALLOW_DOWNGRADE=0

--- a/rpi-eeprom-update-default
+++ b/rpi-eeprom-update-default
@@ -16,9 +16,8 @@ EEPROM_CONFIG_HOOK=
 # AB_EEPROM can be set here to override auto-detection of AB EEPROM support
 #AB_EEPROM=
 
-# Set STRICT_MIN_VER_CHECK to 1 to treat bootloader manufacturing min-version checks as a fatal error
-# Default is currently 0
-#STRICT_MIN_VER_CHECK=1
+# Set to 0 to only warn if the image MFG_VER is older than the board requires
+#STRICT_MIN_VER_CHECK=0
 
 # Set to 1 to install an older bootloader without confirmation
-#RPI_EEPROM_ALLOW_DOWNGRADE=0
+#RPI_EEPROM_ALLOW_DOWNGRADE=1


### PR DESCRIPTION
In addition to the version check change the default behaviour to never downgrade the bootloader to an older version without prompting the user unless the '-y' flag is passed.

Also, add defensive code to verify that the update timestamp specified in device-tree is valid and that the node is present e.g. if u-boot is used and device-tree does not match RPI OS expected layout for the bootloader.